### PR TITLE
Fix bug in SOC Calculation

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,4 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
-__all__ = ['sim', 'model_gen', 'benchmarking', 'new_model', 'sensitivity', 'noise', 'future_loading']
+__all__ = ['sim', 'sim_battery_eol', 'model_gen', 'benchmarking', 'new_model', 'sensitivity', 'noise', 'future_loading']

--- a/examples/sim_battery_eol.py
+++ b/examples/sim_battery_eol.py
@@ -1,0 +1,48 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+"""
+An example where a battery is simulated first for a set period of time and then till threshold is met. Run using the command `python -m examples.sim_example`
+"""
+
+import numpy as np
+from prog_models.models import BatteryElectroChem as Battery
+
+def run_example(): 
+    # Step 1: Create a model object
+    batt = Battery()
+
+    # Step 2: Define future loading function 
+    # Here we're using a function designed to charge until 0.95, 
+    # then discharge until 0.05
+    load = 1
+
+    def future_loading(t, x=None):
+        nonlocal load 
+
+        # Rule for loading after initialization
+        if x is not None:
+            # Current event state in the form {'EOD': <(0, 1)>, 'InsufficientCapacity': <(0, 1)>}
+            event_state = batt.event_state(x)
+            if event_state["EOD"] > 0.95:
+                load = 1  # Discharge
+            elif event_state["EOD"] < 0.05:
+                load = -1  # Charge
+        # Rule for loading at initialization
+        return {'i': load}
+
+    # Simulate to EOL Threshold
+    print('\n\n------------------------------------------------')
+    print('Simulating to threshold\n\n')
+    options = {
+        'save_freq': 1000,  # Frequency at which results are saved
+        'dt': 2,  # Timestep
+        'threshold_keys': ['InsufficientCapacity']  # Simulate to InsufficientCapacity
+    }
+    (times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+
+    for i in range(len(times)): # Print Results
+        print("Time: {}\n\tInput: {}\n\tState: {}\n\tOutput: {}\n\tEvent State: {}\n".format(times[i], inputs[i], states[i], outputs[i], event_states[i]))
+
+# This allows the module to be executed directly 
+if __name__ == '__main__':
+    run_example()

--- a/sphinx_config/getting_started.rst
+++ b/sphinx_config/getting_started.rst
@@ -57,6 +57,12 @@ See the below examples for examples of use. Run these examples using the command
 
 There is also an included tutorial (:download:`tutorial <../tutorial.ipynb>`).
 
+Model Specific examples
+----------
+* :download:`examples.sim_battery_eol <../examples/sim_battery_eol.py>`
+    .. automodule:: examples.sim_battery_eol
+    |
+
 Extending
 ----------
 There are two methods for creating new models: 1. Implementing a new subclass of the base model class (:class:`prog_models.prognostics_model.PrognosticsModel`) or 2. use the model generator method (:py:meth:`prog_models.prognostics_model.PrognosticsModel.generate_model`). These methods are described more below.

--- a/src/prog_models/models/battery_electrochem.py
+++ b/src/prog_models/models/battery_electrochem.py
@@ -272,8 +272,11 @@ class BatteryElectroChemEOD(PrognosticsModel):
         })
         
     def event_state(self, x):
+        z = self.output(x)
+        charge_EOD = (x['qnS'] + x['qnB'])/self.parameters['qnMax']
+        voltage_EOD = (z['v'] - self.parameters['VEOD'])/0.1 # TODO(CT): Make configurable
         return {
-            'EOD': (x['qnS'] + x['qnB'])/self.parameters['qnMax']
+            'EOD': min(charge_EOD, voltage_EOD)
         }
 
     def output(self, x):

--- a/src/prog_models/models/battery_electrochem.py
+++ b/src/prog_models/models/battery_electrochem.py
@@ -384,7 +384,8 @@ class BatteryElectroChemEOL(PrognosticsModel):
         'wq': -1e-2,
         'wr': 1e-6,
         'wd': 1e-2,
-        'qMaxThreshold': 3800
+        'qMaxThreshold': 5320 # Threshold for qMax after which the InsufficientCapacity event has occured
+        # Note: Battery manufacturers specify a threshold of 70-80% of qMax
     }
 
     def initialize(self, u = {}, z = {}):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,17 @@ class TestExamples(unittest.TestCase):
         # Reset stdout 
         sys.stdout = _stdout
 
+    def test_sim_battery_eol_example(self):
+        # set stdout (so it wont print)
+        _stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        # Run example
+        sim_battery_eol.run_example()
+
+        # Reset stdout 
+        sys.stdout = _stdout
+
     def test_benchmark_example(self):
         # set stdout (so it wont print)
         _stdout = sys.stdout


### PR DESCRIPTION
See #43 

Battery EOD model becomes unstable when using SOC to maintain battery change (when simulating to EOD). There are cases where SOC as calculated is >0 but EOD has been met, leading to the above approach simulating past EOD. 

We have never run into this in the past as we've never used SOC to regulate future loading 