### PR TITLE
Save time as array in sim

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -8,6 +8,7 @@ import numpy as np
 from copy import deepcopy
 from collections import UserDict
 import types
+from array import array
 
 
 class PrognosticsModelParameters(UserDict):
@@ -785,7 +786,7 @@ class PrognosticsModel(ABC):
                 return any([thresholds_met[key] for key in threshold_keys])
 
         # Initialization of save arrays
-        times = [t]
+        times = array('d', [0])
         inputs = [u]
         states = [deepcopy(x)]  # Avoid optimization where x is not copied
         saved_outputs = [output(x)]


### PR DESCRIPTION
Save time as an array (instead of list). Slightly faster- but limits type of time to double