### PR TITLE
Implement Prediction Result

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from collections import UserDict
 import types
 from array import array
+from .sim_result import SimResult, CachedSimResult
 
 
 class PrognosticsModelParameters(UserDict):
@@ -782,11 +783,11 @@ class PrognosticsModel(ABC):
                 return any([thresholds_met[key] for key in threshold_keys])
 
         # Initialization of save arrays
-        times = array('d', [0])
-        inputs = [u]
-        states = [deepcopy(x)]  # Avoid optimization where x is not copied
-        saved_outputs = [output(x)]
-        saved_event_states = [event_state(x)]
+        times = array('d')
+        inputs = []
+        states = []  
+        saved_outputs = []
+        saved_event_states = []
         dt = config['dt']  # saving to optimize access in while loop
         save_freq = config['save_freq']
         horizon = config['horizon']
@@ -800,7 +801,7 @@ class PrognosticsModel(ABC):
             def update_all():
                 times.append(t)
                 inputs.append(u)
-                states.append(deepcopy(x))
+                states.append(deepcopy(x))  # Avoid optimization where x is not copied
                 saved_outputs.append(output(x))
                 saved_event_states.append(event_state(x))
                 print("Time: {}\n\tInput: {}\n\tState: {}\n\tOutput: {}\n\tEvent State: {}\n"\
@@ -814,11 +815,10 @@ class PrognosticsModel(ABC):
             def update_all():
                 times.append(t)
                 inputs.append(u)
-                states.append(deepcopy(x))
-                saved_outputs.append(output(x))
-                saved_event_states.append(event_state(x))
+                states.append(deepcopy(x))  # Avoid optimization where x is not copied
         
         # Simulate
+        update_all()
         while t < horizon:
             t += dt
             u = future_loading_eqn(t, x)
@@ -837,7 +837,21 @@ class PrognosticsModel(ABC):
             # This check prevents double recording when the last state was a savepoint
             update_all()
         
-        return (times, inputs, states, saved_outputs, saved_event_states)
+        if not saved_outputs:
+            # saved_outputs is empty, so it wasn't calculated in simulation - used cached result
+            saved_outputs = CachedSimResult(self.output, times, states) 
+            saved_event_states = CachedSimResult(self.event_state, times, states)
+        else:
+            saved_outputs = SimResult(times, saved_outputs)
+            saved_event_states = SimResult(times, saved_event_states)
+        
+        return (
+            times, 
+            SimResult(times, inputs), 
+            SimResult(times, states), 
+            saved_outputs, 
+            saved_event_states
+        )
     
     @staticmethod
     def generate_model(keys, initialize_eqn, output_eqn, next_state_eqn = None, dx_eqn = None, event_state_eqn = None, threshold_eqn = None, config = {'process_noise': 0.1}):

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -26,7 +26,7 @@ class SimResult(UserList):
         return self.times[index]
 
 
-class CachedSimResult(UserList):
+class CachedSimResult(SimResult):
     """
     Used to store the result of a simulation, which is only calculated on first request
     """
@@ -41,17 +41,6 @@ class CachedSimResult(UserList):
         self.times = times
         self.states = states
         self.__data = None
-
-    def time(self, index):
-        """Get time for data point at index `index`
-
-        Args:
-            index (int)
-
-        Returns:
-            float: Time for which the data point at index `index` corresponds
-        """
-        return self.times[index]
 
     @property
     def data(self):

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -1,0 +1,67 @@
+from collections import UserList
+
+
+class SimResult(UserList):
+    """
+    Used to store the result of a simulation, with time 
+    """
+    def __init__(self, times, data):
+        """
+        Args:
+            times (array(float)): Times for each data point where times[n] corresponds to data[n]
+            data (array(dict)): Data points where data[n] corresponds to times[n]
+        """
+        self.times = times
+        self.data = data
+
+    def time(self, index):
+        """Get time for data point at index `index`
+
+        Args:
+            index (int)
+
+        Returns:
+            float: Time for which the data point at index `index` corresponds
+        """
+        return self.times[index]
+
+
+class CachedSimResult(UserList):
+    """
+    Used to store the result of a simulation, which is only calculated on first request
+    """
+    def __init__(self, fcn, times, states):
+        """
+        Args:
+            fcn (callable): function (x) -> z where x is the state and z is the data
+            times (array(float)): Times for each data point where times[n] corresponds to data[n]
+            data (array(dict)): Data points where data[n] corresponds to times[n]
+        """
+        self.fcn = fcn
+        self.times = times
+        self.states = states
+        self.__data = None
+
+    def time(self, index):
+        """Get time for data point at index `index`
+
+        Args:
+            index (int)
+
+        Returns:
+            float: Time for which the data point at index `index` corresponds
+        """
+        return self.times[index]
+
+    @property
+    def data(self):
+        """
+        Get the data (elements of list). Only calculated on first request
+
+        Returns:
+            array(dict): data
+        """
+        if self.__data is None:
+            self.__data = [self.fcn(x) for x in self.states]
+        return self.__data
+    

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -15,6 +15,17 @@ class SimResult(UserList):
         self.times = times
         self.data = data
 
+    def __eq__(self, other):
+        """Compare 2 SimResults
+
+        Args:
+            other (SimResult)
+
+        Returns:
+            bool: If the two SimResults are equal
+        """
+        return self.times == other.times and self.data == other.data
+
     def time(self, index):
         """Get time for data point at index `index`
 

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -1,4 +1,5 @@
 from collections import UserList
+from .visualize import plot_timeseries
 
 
 class SimResult(UserList):
@@ -25,6 +26,8 @@ class SimResult(UserList):
         """
         return self.times[index]
 
+    def plot(self, **kwargs):
+        plot_timeseries(self.times, self.data, options=kwargs)
 
 class CachedSimResult(SimResult):
     """

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -45,6 +45,9 @@ class CachedSimResult(SimResult):
         self.states = states
         self.__data = None
 
+    def is_cached(self):
+        return self.__data is not None
+
     @property
     def data(self):
         """

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -36,6 +36,11 @@ if __name__ == '__main__':
         was_successful = False
 
     try:
+        exec(open("tests/test_sim_result.py").read())
+    except Exception:
+        was_successful = False
+
+    try:
         exec(open("tests/test_examples.py").read())
     except Exception:
         was_successful = False

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -1,0 +1,72 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
+
+import unittest
+from prog_models.sim_result import SimResult, CachedSimResult
+
+class TestSimResult(unittest.TestCase):
+    def test_sim_result(self):
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = SimResult(time, state)
+        self.assertListEqual(list(result), state)
+        self.assertListEqual(result.times, time)
+        for i in range(5):
+            self.assertEqual(result.time(i), time[i])
+            self.assertEqual(result[i], state[i])
+
+        try:
+            tmp = result[NUM_ELEMENTS]
+            self.fail("Should be out of range error")
+        except IndexError:
+            pass
+
+        try:
+            tmp = result.time(NUM_ELEMENTS)
+            self.fail("Should be out of range error")
+        except IndexError:
+            pass
+    
+    def test_cached_sim_result(self):
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = CachedSimResult(f, time, state)
+        self.assertFalse(result.is_cached())
+        self.assertListEqual(result.times, time)
+        for i in range(5):
+            self.assertEqual(result.time(i), time[i])
+            self.assertEqual(result[i], state[i]*2)
+        self.assertTrue(result.is_cached())
+
+        try:
+            tmp = result[NUM_ELEMENTS]
+            self.fail("Should be out of range error")
+        except IndexError:
+            pass
+
+        try:
+            tmp = result.time(NUM_ELEMENTS)
+            self.fail("Should be out of range error")
+        except IndexError:
+            pass
+
+# This allows the module to be executed directly
+def run_tests():
+    unittest.main()
+    
+if __name__ == '__main__':
+    # This ensures that the directory containing ProgModelTemplate is in the python search directory
+    import sys
+    from os.path import dirname, join
+    sys.path.append(join(dirname(__file__), ".."))
+
+    l = unittest.TestLoader()
+    runner = unittest.TextTestRunner()
+    print("\n\nTesting Sim Result")
+    result = runner.run(l.loadTestsFromTestCase(TestSimResult)).wasSuccessful()
+
+    if not result:
+        raise Exception("Failed test")

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -54,7 +54,6 @@
     "\n",
     "The `prog_models` package has the following structure\n",
     "* `prog_models.PrognosticsModel` - parent class for all prognostics models - defines interfaces that a model must implement, and tools for simulating said model \n",
-    "* `prog_models.visualize` - tools for visualizing the results of a simulation \n",
     "* `prog_models.models.*` - implemented models (e.g., pump, valve, battery)\n",
     "\n",
     "In addition to the `prog_models` package, this repo includes examples showing how to use the package (see `examples/`), a template for implementing a new model (`prog_model_template`), documentation (`docs/`), and this tutorial (`tutorial.ipynb`).\n",
@@ -268,19 +267,17 @@
    "source": [
     "first_output = {'t': 18.95, 'v': 4.183} # temperature of 18.95, and voltage of 4.183\n",
     "time_to_simulate_to = 200\n",
-    "sim_config = {'save_freq': 20}\n",
-    "(times, inputs, states, outputs, event_states) = batt.simulate_to(time_to_simulate_to, future_loading, first_output, **sim_config)\n",
-    "\n",
-    "for i in range(len(times)): # Print Results\n",
-    "    print(\"Time: {}\\n\\tInput: {}\\n\\tState: {}\\n\\tOutput: {}\\n\\tEvent State: {}\\n\".format(times[i], inputs[i], states[i], outputs[i], event_states[i]))"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "sim_config = {\n",
+    "    'save_freq': 20, \n",
+    "    'print': True  # Print states - Note: is much faster without\n",
+    "}\n",
+    "(times, inputs, states, outputs, event_states) = batt.simulate_to(time_to_simulate_to, future_loading, first_output, **sim_config)"
+   ]
   },
   {
    "cell_type": "markdown",
    "source": [
-    "We can also use the visualize package to plot the results"
+    "We can also plot the results"
    ],
    "metadata": {}
   },
@@ -288,12 +285,9 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "from prog_models import visualize\n",
-    "visualize.plot_timeseries( times, event_states, options={'ylabel': 'SOC'})\n",
-    "visualize.plot_timeseries( times, outputs, options={'ylabel': {'v': \"voltage (V)\", 't': 'temperature (°C)'}, 'compact': False})\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "event_states.plot(ylabel= 'SOC')\n",
+    "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -313,11 +307,9 @@
     "    'horizon': 5000 # Maximum time to simulate (s) - This is a cutoff. The simulation will end at this time, or when a threshold has been met, whichever is first\n",
     "    }\n",
     "(times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)\n",
-    "visualize.plot_timeseries( times, event_states, options={'ylabel': 'SOC'})\n",
-    "visualize.plot_timeseries( times, outputs, options={'ylabel': {'v': \"voltage (V)\", 't': 'temperature (°C)'}, 'compact': False})"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "event_states.plot(ylabel='SOC')\n",
+    "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -487,11 +479,9 @@
     "\n",
     "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':thrower_height}, threshold_keys=[event], dt=0.005, save_freq=1)\n",
     "\n",
-    "visualize.plot_timeseries( times, event_states, options={'ylabel': ['falling', 'impact'], 'compact': False})\n",
-    "visualize.plot_timeseries( times, states, options={'ylabel': {'x': \"position (m)\", 'v': 'velocity (m/s)'}, 'compact': False})"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
+    "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -590,12 +580,9 @@
     "\n",
     "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)\n",
     "\n",
-    "from prog_models import visualize\n",
-    "visualize.plot_timeseries( times, event_states, options={'ylabel': ['falling', 'impact'], 'compact': False})\n",
-    "visualize.plot_timeseries( times, states, options={'ylabel': {'x': \"position (m)\", 'v': 'velocity (m/s)'}, 'compact': False})"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
+    "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR implements the Prediction Result class - adding capabilities to what is returned from a simulation. 

@jason-watkins, @wlamberson1: This goes against your suggestion. I tried implementing both and found this version with significantly cleaner and easier to use. This can also be extendable to analysis tools/operations comparisons (e.g., diff_outputs = output1 - outputs2). Since this is a research rather than an tool for deployment, I selected the easier to use/more expandable option accepting the inefficiency of duplicate storages of time.

I would still like your input on this implementation