### PR TITLE
Fixed 2 LGTM alerts

### DIFF
--- a/src/prog_models/models/pneumatic_valve.py
+++ b/src/prog_models/models/pneumatic_valve.py
@@ -2,7 +2,6 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from .. import prognostics_model
-from ..exceptions import ProgModelException
 from math import sqrt, copysign, inf
 from copy import deepcopy
 

--- a/src/prog_models/models/pneumatic_valve.py
+++ b/src/prog_models/models/pneumatic_valve.py
@@ -195,9 +195,8 @@ class PneumaticValveBase(prognostics_model.PrognosticsModel):
             return C*A*pIn*sqrt(2/Z/R/T*k/(k-1)*abs((pOut/pIn)**(2/k)-(pOut/pIn)**((k+1)/k)))
         if pOut/pIn>=threshold:
             return -C*A*pOut*sqrt(k/Z/R/T*(2/(k+1))**((k+1)/(k-1)))
-        if pOut>pIn:
-            return -C*A*pOut*sqrt(2/Z/R/T*k/(k-1)*abs((pIn/pOut)**(2/k)-(pIn/pOut)**((k+1)/k)))
-        raise ProgModelException('Unknown Condition')
+        # pOut>pIn but pOut/pIn < threshold - only remaining possibility 
+        return -C*A*pOut*sqrt(2/Z/R/T*k/(k-1)*abs((pIn/pOut)**(2/k)-(pIn/pOut)**((k+1)/k)))
     
     def next_state(self, x, u, dt):
         params = self.parameters # optimization

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -38,7 +38,8 @@ class SimResult(UserList):
         return self.times[index]
 
     def plot(self, **kwargs):
-        plot_timeseries(self.times, self.data, options=kwargs)
+        plot_timeseries(self.times, self.data, options=kwargs)  
+    # lgtm [py/missing-equals]
 
 class CachedSimResult(SimResult):
     """


### PR DESCRIPTION
Fixed 2 alerts:
 1. Unnecessary condition in if/else (no other state was possible
 2. __eq__ not overwritten (this is not necessary as the comparison is identical to it's parent class