### PR TITLE
Moved limit checking into function

### DIFF
--- a/examples/state_limits.py
+++ b/examples/state_limits.py
@@ -57,6 +57,13 @@ def run_example():
     print('Example 3')
     (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=0.3, x = x0, print = True)
 
+    # Note that the limits can also be applied manually using the apply_limits function
+    print('limiting states')
+    x = {'x': -5, 'v': 3e8}  # Too fast and below the ground
+    print('\t Pre-limit: {}'.format(x))
+    x = m.apply_limits(x)
+    print('\t Post-limit: {}'.format(x))
+
 # This allows the module to be executed directly 
 if __name__=='__main__':
     run_example()

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -748,15 +748,28 @@ class TestModels(unittest.TestCase):
         self.assertGreaterEqual(states[1]['t'], -100)
         self.assertLessEqual(states[1]['t'], 100)
 
+        # now using the fcn
+        x0['t'] = 0
+        x = m.apply_limits(x0)
+        self.assertAlmostEqual(x['t'], 0, 9)
+
         # outside low boundary
         x0['t'] = -200
         (times, inputs, states, outputs, event_states) = m.simulate_to(0.001, load, {'o1': 0.8}, x = x0)
         self.assertAlmostEqual(states[1]['t'], -100)
 
+        x0['t'] = -200
+        x = m.apply_limits(x0)
+        self.assertAlmostEqual(x['t'], -100, 9)
+
         # outside high boundary
         x0['t'] = 200
         (times, inputs, states, outputs, event_states) = m.simulate_to(0.001, load, {'o1': 0.8}, x = x0)
         self.assertAlmostEqual(states[1]['t'], 100)
+
+        x0['t'] = 200
+        x = m.apply_limits(x0)
+        self.assertAlmostEqual(x['t'], 100, 9)
 
         # at low boundary
         x0['t'] = -100
@@ -764,11 +777,19 @@ class TestModels(unittest.TestCase):
         self.assertGreaterEqual(states[1]['t'], -100)
         self.assertLessEqual(states[1]['t'], 100)
 
+        x0['t'] = -100
+        x = m.apply_limits(x0)
+        self.assertAlmostEqual(x['t'], -100, 9)
+
         # at high boundary
         x0['t'] = 100
         (times, inputs, states, outputs, event_states) = m.simulate_to(0.001, load, {'o1': 0.8}, x = x0)
         self.assertGreaterEqual(states[1]['t'], -100)
         self.assertLessEqual(states[1]['t'], 100)
+
+        x0['t'] = 100
+        x = m.apply_limits(x0)
+        self.assertAlmostEqual(x['t'], 100, 9)
 
         # when state doesn't exist
         try:

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -10,12 +10,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.6.15"
   },
   "orig_nbformat": 2,
   "kernelspec": {
    "name": "python3",
-   "display_name": "Python 3.8.11 64-bit"
+   "display_name": "Python 3.6.15 64-bit"
   },
   "metadata": {
    "interpreter": {
@@ -23,7 +23,7 @@
    }
   },
   "interpreter": {
-   "hash": "ff94885aa2d97705a9dae03869c2058fa855d1acd9df351499300343e2e591a2"
+   "hash": "c1e35f02e3a88578371dd5b5d88a204463a98b2d7cd5222657e170520db47be1"
   }
  },
  "nbformat": 4,
@@ -272,7 +272,9 @@
     "    'print': True  # Print states - Note: is much faster without\n",
     "}\n",
     "(times, inputs, states, outputs, event_states) = batt.simulate_to(time_to_simulate_to, future_loading, first_output, **sim_config)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -287,7 +289,9 @@
    "source": [
     "event_states.plot(ylabel= 'SOC')\n",
     "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)\n"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -309,7 +313,9 @@
     "(times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)\n",
     "event_states.plot(ylabel='SOC')\n",
     "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -481,7 +487,9 @@
     "\n",
     "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
     "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -496,6 +504,7 @@
    "execution_count": null,
    "source": [
     "from prog_models import PrognosticsModel\n",
+    "from math import inf\n",
     "\n",
     "# Model used in example\n",
     "class ThrownObject(PrognosticsModel):\n",
@@ -522,6 +531,15 @@
     "        'throwing_speed': 40, # m/s\n",
     "        'g': -9.81, # Acceleration due to gravity in m/s^2\n",
     "        'process_noise': 0.0 # amount of noise in each step\n",
+    "    }\n",
+    "    \n",
+    "    # Set limits for the values of each state (optional)\n",
+    "    state_limits = {\n",
+    "        # object may not go below ground height\n",
+    "        'x': (0, inf),\n",
+    "\n",
+    "        # object may not exceed the speed of light\n",
+    "        'v': (-299792458, 299792458)\n",
     "    }\n",
     "\n",
     "    def initialize(self, u, z):\n",
@@ -582,7 +600,9 @@
     "\n",
     "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
     "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -635,6 +655,31 @@
     "ThrownObject.param_callbacks = {}"
    ],
    "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Note: State limits can be applied directly using the apply_limits function. For example:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "x = {'x': -5, 'v': 3e8} # Too fast and below the ground\n",
+    "x = obj.apply_limits(x)\n",
+    "print(x)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Notice how the state was limited according to the model state limits"
+   ],
    "metadata": {}
   },
   {


### PR DESCRIPTION
v1.1 added the state bounding feature. There is some user interest in creating a separate function to apply bounds (. apply_limits(state) -> state) that is called from within __next_state(). This would enable other methods that externally agitate state (e.g., particle filters) to ensure they remain within bounds. 

## Definition of Done
- [ ] Implement . apply_bounds function in PrognosticsModel
- [ ] Update __next_state to use .apply_limits
- [ ] Create test
- [ ] Add to tutorial, example