### PR TITLE
Fix typo in derived_params example

### DIFF
--- a/examples/derived_params.py
+++ b/examples/derived_params.py
@@ -25,7 +25,7 @@ def run_example():
     ThrownObject.param_callbacks = {
             'thrower_height': [update_thrown_speed]
         }  # Tell the derived callbacks feature to call this function when thrower_height changes.
-    # Note: Usually we would define this menthod within the class
+    # Note: Usually we would define this method within the class
     #  for this example, we're doing it separately to improve readability
     # Note2: You can also have more than one function be called when a single parameter is changed.
     #  Do this by adding the additional callbacks to the list (e.g., 'thrower_height': [update_thrown_speed, other_fcn])


### PR DESCRIPTION
Hi,

I noticed this typo while reading examples.

Kind regards,