### PR TITLE
Make initial output and input optional in initialize

### DIFF
--- a/examples/benchmarking.py
+++ b/examples/benchmarking.py
@@ -30,7 +30,7 @@ def run_example():
     # Step 3: Benchmark simulation for 600 seconds
     print('Benchmarking:')
     def sim():  
-        (times, inputs, states, outputs, event_states) = batt.simulate_to(600, future_loading, {'t': 18.95, 'v': 4.183})
+        (times, inputs, states, outputs, event_states) = batt.simulate_to(600, future_loading)
     time = timeit(sim, number=500)
 
     # Print results

--- a/examples/dynamic_step_size.py
+++ b/examples/dynamic_step_size.py
@@ -30,7 +30,7 @@ def run_example():
     # Here we're printing every time step so we can see the step size change
     print('\n\n------------------------------------------------')
     print('Simulating to threshold\n\n')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, save_freq=1e-99, print=True, dt=next_time, threshold_keys=['impact'])
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, save_freq=1e-99, print=True, dt=next_time, threshold_keys=['impact'])
 
     # Example 2
     print("EXAMPLE 2: dt of 1 until impact event state 0.5, then 0.25 \n\nSetting up...\n")
@@ -49,7 +49,7 @@ def run_example():
     # Here we're printing every time step so we can see the step size change
     print('\n\n------------------------------------------------')
     print('Simulating to threshold\n\n')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, save_freq=1e-99, print=True, dt=next_time, threshold_keys=['impact'])
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, save_freq=1e-99, print=True, dt=next_time, threshold_keys=['impact'])
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/examples/future_loading.py
+++ b/examples/future_loading.py
@@ -32,7 +32,7 @@ def run_example():
         'save_freq': 100,  # Frequency at which results are saved
         'dt': 2  # Timestep
     }
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
     plot_timeseries(times, inputs, options={'ylabel': 'Variable Load Current (amps)'})
@@ -68,7 +68,7 @@ def run_example():
     
     # Now the future_loading eqn is setup to use the moving average of whats been seen
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
     plot_timeseries(times, inputs, options={'ylabel': 'Moving Average Current (amps)'})
@@ -98,7 +98,7 @@ def run_example():
     future_loading.std = 0.2
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
     plot_timeseries(times, inputs, options={'ylabel': 'Variable Gaussian Current (amps)'})
@@ -137,7 +137,7 @@ def run_example():
         moving_avg({'i': load})
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
     plot_timeseries(times, inputs, options={'ylabel': 'Moving Average Current (amps)'})
@@ -159,7 +159,7 @@ def run_example():
     future_loading.start = 0.5
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
     plot_timeseries(times, inputs, options={'ylabel': 'Moving Average Current (amps)'})

--- a/examples/model_gen.py
+++ b/examples/model_gen.py
@@ -74,7 +74,7 @@ def run_example():
 
     # Step 8: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':thrower_height}, threshold_keys=[event], dt = 0.005, save_freq=1, print = True)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt = 0.005, save_freq=1, print = True)
     
     # Print flight time
     print('The object hit the ground in {} seconds'.format(round(times[-1],2)))

--- a/examples/new_model.py
+++ b/examples/new_model.py
@@ -74,7 +74,7 @@ def run_example():
 
     # Step 3: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1, print = True)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, print = True)
     
     # Print flight time
     print('The object hit the ground in {} seconds'.format(round(times[-1],2)))
@@ -85,16 +85,16 @@ def run_example():
 
     # The first way to change the configuration is to pass in your desired config into construction of the model
     m = ThrownObject(g = grav_moon)
-    (times_moon, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    (times_moon, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     grav_mars = -3.711
     # You can also update the parameters after it's constructed
     m.parameters['g'] = grav_mars
-    (times_mars, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    (times_mars, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     grav_venus = -8.87
     m.parameters['g'] = grav_venus
-    (times_venus, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    (times_venus, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     print('Time to hit the ground: ')
     print('\tvenus: {}s'.format(round(times_venus[-1],2)))
@@ -103,7 +103,7 @@ def run_example():
     print('\tmoon: {}s'.format(round(times_moon[-1],2)))
 
     # We can also simulate until any event is met by neglecting the threshold_keys argument
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, options={'dt':0.005, 'save_freq':1})
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, options={'dt':0.005, 'save_freq':1})
     threshs_met = m.threshold_met(states[-1])
     for (key, met) in threshs_met.items():
         if met:

--- a/examples/noise.py
+++ b/examples/noise.py
@@ -16,7 +16,7 @@ def run_example():
     # Ex1: No noise
     process_noise = 0
     m = ThrownObject(process_noise = process_noise)
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('Example without noise')
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
@@ -25,7 +25,7 @@ def run_example():
     process_noise = 0.5
     m = ThrownObject(process_noise = process_noise)  # Noise with a std of 0.5 to every state
     print('\nExample without same noise for every state')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
 
@@ -33,7 +33,7 @@ def run_example():
     process_noise = {'x': 0.25, 'v': 0.75}
     m = ThrownObject(process_noise = process_noise) 
     print('\nExample with more noise on position than velocity')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
 
@@ -43,7 +43,7 @@ def run_example():
     model_config = {'process_noise_dist': process_noise_dist, 'process_noise': process_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with more uniform noise')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
 
@@ -53,7 +53,7 @@ def run_example():
     model_config = {'process_noise_dist': process_noise_dist, 'process_noise': process_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with triangular process noise')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
 
@@ -65,7 +65,7 @@ def run_example():
     model_config = {'measurement_noise_dist': measurement_noise_dist, 'measurement_noise': measurement_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with measurement noise')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- outputs: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, outputs)])) 
     print('\t- impact time: {}s'.format(times[-1]))
@@ -81,7 +81,7 @@ def run_example():
     model_config = {'process_noise': apply_proportional_process_noise}
     m = ThrownObject(**model_config)
     print('\nExample with proportional noise on velocity')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
     print('\t- impact time: {}s'.format(times[-1]))
 

--- a/examples/sensitivity.py
+++ b/examples/sensitivity.py
@@ -26,8 +26,7 @@ def run_example():
     eods = np.empty(len(thrower_height_range))
     for (i, thrower_height) in zip(range(len(thrower_height_range)), thrower_height_range):
         m.parameters['thrower_height'] = thrower_height
-        z_i = {'x': thrower_height} # First output 
-        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, z_i, threshold_keys=[event], dt =1e-3, save_freq =10)
+        (times, _, _, _, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt =1e-3, save_freq =10)
         eods[i] = times[-1]
 
     # Step 5: Analysis
@@ -41,7 +40,7 @@ def run_example():
     eods = np.empty(len(throw_speed_range))
     for (i, throw_speed) in zip(range(len(throw_speed_range)), throw_speed_range):
         m.parameters['throwing_speed'] = throw_speed
-        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], options={'dt':1e-3, 'save_freq':10})
+        (times, _, _, _, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':1e-3, 'save_freq':10})
         eods[i] = times[-1]
 
     print('\nFor a reasonable range of throwing speeds, impact time is between {} and {}'.format(round(eods[0],3), round(eods[-1],3)))

--- a/examples/sim.py
+++ b/examples/sim.py
@@ -30,7 +30,7 @@ def run_example():
     # simulate for 200 seconds
     print('\n\n------------------------------------------------')
     print('Simulating for 200 seconds\n\n')
-    (times, inputs, states, outputs, event_states) = batt.simulate_to(200, future_loading, {'t': 18.95, 'v': 4.183}, print = True)
+    (times, inputs, states, outputs, event_states) = batt.simulate_to(200, future_loading, print = True)
 
     # Simulate to threshold
     print('\n\n------------------------------------------------')
@@ -40,7 +40,7 @@ def run_example():
         'dt': 2, # Timestep
         'print': True
     }
-    (times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, **options)
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/examples/sim_battery_eol.py
+++ b/examples/sim_battery_eol.py
@@ -39,7 +39,7 @@ def run_example():
         'threshold_keys': ['InsufficientCapacity'],  # Simulate to InsufficientCapacity
         'print': True
     }
-    (times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)
+    (times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, **options)
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/examples/state_limits.py
+++ b/examples/state_limits.py
@@ -28,7 +28,7 @@ def run_example():
 
     # Step 3: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     
     # Print states
     print('Example 1')
@@ -40,7 +40,7 @@ def run_example():
     x0 = m.initialize(u = {}, z = {})
     x0['x'] = -1
 
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1, x = x0)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, x = x0)
 
     # Print states
     print('Example 2')
@@ -55,7 +55,7 @@ def run_example():
     m.parameters['g'] = -50000000
     
     print('Example 3')
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=0.3, x = x0, print = True)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=0.3, x = x0, print = True)
 
     # Note that the limits can also be applied manually using the apply_limits function
     print('limiting states')

--- a/examples/vectorized.py
+++ b/examples/vectorized.py
@@ -23,13 +23,13 @@ def run_example():
 
     # Step 3: Simulate to threshold
     # Here we are simulating till impact using the first state defined above
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x': first_state['x']}, x = first_state, threshold_keys=['impact'], print = True, dt=0.1, save_freq=2)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, x = first_state, threshold_keys=['impact'], print = True, dt=0.1, save_freq=2)
 
     # Now lets do the same thing but only stop when all hit the ground
     def thresholds_met_eqn(thresholds_met):
         return all(thresholds_met['impact'])  # Stop when all impact ground
 
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x': first_state['x']}, x = first_state, thresholds_met_eqn=thresholds_met_eqn, print = True, dt=0.1, save_freq=2)
+    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, x = first_state, thresholds_met_eqn=thresholds_met_eqn, print = True, dt=0.1, save_freq=2)
 
 # This allows the module to be executed directly 
 if __name__=='__main__':

--- a/examples/visualize.py
+++ b/examples/visualize.py
@@ -19,10 +19,8 @@ def run_example():
 
     # Step 3: Simulate to impact
     event = 'impact'
-    first_output = {'x':m.parameters['thrower_height']}
     options={'dt':0.005, 'save_freq':1}
     (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load,
-                                                                             first_output, 
                                                                              threshold_keys=[event], 
                                                                              **options)
     

--- a/prog_model_template.py
+++ b/prog_model_template.py
@@ -99,7 +99,10 @@ class ProgModelTemplate(PrognosticsModel):
 
         super().__init__(**kwargs) # Run Parent constructor
 
-    def initialize(self, u, z):
+    # Sometimes initial input (u) and initial output (z) are needed to initialize the model
+    # In that case remove the '= None' for the appropriate argument
+    # Note: If they are needed, that requirement propogated through to the simulate_to* functions
+    def initialize(self, u=None, z=None):
         """
         Calculate initial state given inputs and outputs
 

--- a/src/prog_models/models/battery_circuit.py
+++ b/src/prog_models/models/battery_circuit.py
@@ -1,13 +1,13 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
-from .. import prognostics_model
+from .. import PrognosticsModel
 
 from math import inf
 from numpy import exp, minimum
 
 
-class BatteryCircuit(prognostics_model.PrognosticsModel):
+class BatteryCircuit(PrognosticsModel):
     """
     Prognostics model for a battery, represented by an electric circuit
     
@@ -114,7 +114,7 @@ class BatteryCircuit(prognostics_model.PrognosticsModel):
         'qb': (0, inf)
     }
 
-    def initialize(self, u={}, z={}):
+    def initialize(self, u=None, z=None):
         return self.parameters['x0']
 
     def dx(self, x, u):

--- a/src/prog_models/models/battery_electrochem.py
+++ b/src/prog_models/models/battery_electrochem.py
@@ -232,7 +232,7 @@ class BatteryElectroChemEOD(PrognosticsModel):
         'xnMax': [update_qmax, update_qnmax, update_qnSBmax]
     }
 
-    def initialize(self, u = {}, z = {}):
+    def initialize(self, u=None, z=None):
         return self.parameters['x0']
 
     def dx(self, x, u):
@@ -419,7 +419,7 @@ class BatteryElectroChemEOL(PrognosticsModel):
         'qMax': (0, inf)
     }
 
-    def initialize(self, u = {}, z = {}):
+    def initialize(self, u=None, z=None):
         return self.parameters['x0']
 
     def dx(self, x, u):

--- a/src/prog_models/models/thrown_object.py
+++ b/src/prog_models/models/thrown_object.py
@@ -36,7 +36,7 @@ class ThrownObject(PrognosticsModel):
         super().__init__(**kwargs)
         self.max_x = 0.0
 
-    def initialize(self, u, z):
+    def initialize(self, u=None, z=None):
         return {
             'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
             'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -645,7 +645,7 @@ class PrognosticsModel(ABC):
         future_loading_eqn : callable
             Function of (t) -> z used to predict future loading (output) at a given time (t)
         first_output : dict, optional
-            First measured output, needed to initialize state for some classes. Can be ommited for classes that dont use this
+            First measured output, needed to initialize state for some classes. Can be omitted for classes that dont use this
         options: kwargs, optional
             Configuration options for the simulation \n
             Note: configuration of the model is set through model.parameters \n
@@ -706,7 +706,7 @@ class PrognosticsModel(ABC):
         future_loading_eqn : callable
             Function of (t) -> z used to predict future loading (output) at a given time (t)
         first_output : dict, optional
-            First measured output, needed to initialize state for some classes. Can be ommited for classes that dont use this
+            First measured output, needed to initialize state for some classes. Can be omitted for classes that dont use this
         threshold_keys: [str], optional
             Keys for events that will trigger the end of simulation.
             If blank, simulation will occur if any event will be met ()

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -232,7 +232,7 @@ class PrognosticsModel(ABC):
         return "{} Prognostics Model (Events: {})".format(type(self).__name__, self.events)
     
     @abstractmethod
-    def initialize(self, u, z) -> dict:
+    def initialize(self, u = None, z = None) -> dict:
         """
         Calculate initial state given inputs and outputs
 
@@ -633,7 +633,7 @@ class PrognosticsModel(ABC):
         return {key: event_state <= 0 \
             for (key, event_state) in self.event_state(x).items()} 
 
-    def simulate_to(self, time, future_loading_eqn, first_output, **kwargs) -> tuple:
+    def simulate_to(self, time, future_loading_eqn, first_output = None, **kwargs) -> tuple:
         """
         Simulate prognostics model for a given number of seconds
 
@@ -644,6 +644,8 @@ class PrognosticsModel(ABC):
             e.g., time = 200
         future_loading_eqn : callable
             Function of (t) -> z used to predict future loading (output) at a given time (t)
+        first_output : dict, optional
+            First measured output, needed to initialize state for some classes. Can be ommited for classes that dont use this
         options: kwargs, optional
             Configuration options for the simulation \n
             Note: configuration of the model is set through model.parameters \n
@@ -695,7 +697,7 @@ class PrognosticsModel(ABC):
 
         return self.simulate_to_threshold(future_loading_eqn, first_output, **kwargs)
  
-    def simulate_to_threshold(self, future_loading_eqn, first_output, threshold_keys = None, **kwargs) -> tuple:
+    def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs) -> tuple:
         """
         Simulate prognostics model until any or specified threshold(s) have been met
 
@@ -703,8 +705,8 @@ class PrognosticsModel(ABC):
         ----------
         future_loading_eqn : callable
             Function of (t) -> z used to predict future loading (output) at a given time (t)
-        first_output : dict
-            First measured output, needed to initialize state
+        first_output : dict, optional
+            First measured output, needed to initialize state for some classes. Can be ommited for classes that dont use this
         threshold_keys: [str], optional
             Keys for events that will trigger the end of simulation.
             If blank, simulation will occur if any event will be met ()
@@ -754,7 +756,7 @@ class PrognosticsModel(ABC):
         | (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load_eqn, first_output)
         """
         # Input Validation
-        if not all(key in first_output for key in self.outputs):
+        if first_output and not all(key in first_output for key in self.outputs):
             raise ProgModelInputException("Missing key in 'first_output', must have every key in model.outputs")
 
         if not (callable(future_loading_eqn)):

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -609,7 +609,7 @@ class TestModels(unittest.TestCase):
             pass
 
         try:
-            m.simulate_to(12, load, {})
+            m.simulate_to(12, load, {'o2': 0.9})
             self.fail("Should have failed- output must contain each field (e.g., o1)")
         except ProgModelInputException:
             pass

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -1,43 +1,15 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.15"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.6.15 64-bit"
-  },
-  "metadata": {
-   "interpreter": {
-    "hash": "c1e35f02e3a88578371dd5b5d88a204463a98b2d7cd5222657e170520db47be1"
-   }
-  },
-  "interpreter": {
-   "hash": "c1e35f02e3a88578371dd5b5d88a204463a98b2d7cd5222657e170520db47be1"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Welcome to the Prognostics Model Library Tutorial"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The goal of this notebook is to instruct users on how to use and extend the NASA PCoE Python Prognostics Model Package. \n",
     "\n",
@@ -61,174 +33,175 @@
     "Before you start, make sure that all the required packages are installed (see `requirements.txt`)\n",
     "\n",
     "Now lets get started with some examples"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Using the included models\n",
     "\n",
     "This first example is for using the included prognostics models. First thing to do is to import the model you would like to use:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from prog_models.models import BatteryCircuit"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This imports the battery_circuit model distributed with the `prog_models` package. \n",
     "\n",
     "Next, lets create a new battery using the default settings:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "batt = BatteryCircuit()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This creates a battery circuit model. You can also pass configuration parameters into the constructor as kwargs to configure the system, for example\n",
     "### <center>`BatteryCircuit(process_noise= 0)`</center>\n",
     "\n",
     "Alternatively, you can set the configuration of the system afterwards, like so:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "batt.parameters['process_noise'] = 0 # No process noise"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Lets use the member properties to check out some details of the model, first the model configuration:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print('configuration: ', batt.parameters)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "You can also save or load your model configuration using pickle"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import pickle\n",
     "pickle.dump(batt.parameters, open('ex.pickle', 'wb'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Then you can set your model configuration like below. This is useful for recording and restoring model configurations"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "batt.parameters = pickle.load(open('ex.pickle', 'rb'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next the expected inputs (loading) and outputs (measurements)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print('inputs: ', batt.inputs)\n",
     "print('outputs: ', batt.outputs)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now lets look at what event we're predicting. This model only predicts one event, but that's not true for every model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print('event(s): ', batt.events)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Finally, let's take a look at the internal states that the model uses to represent the system:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print('states: ', batt.states)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "All those checks were just to take a look at the properties of this model. Now let's work towards simulating. \n",
     "\n",
     "Next, we define future loading. This is a function that describes how the system will be loaded as a function of time. Here we're defining a basic peasewise function."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def future_loading(t, x=None):\n",
     "    # Variable (piece-wise) future loading scheme \n",
@@ -243,89 +216,87 @@
     "    else:\n",
     "        i = 3\n",
     "    return {'i': i}"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "At last it's time to simulate. First we're going to simulate forward 200 seconds. To do this we have to define our first expected output (e.g., measurement) to initialize the model state. Then we're going to use the function simulate_to() to simulate to the specified time and print the results"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "first_output = {'t': 18.95, 'v': 4.183} # temperature of 18.95, and voltage of 4.183\n",
     "time_to_simulate_to = 200\n",
     "sim_config = {\n",
     "    'save_freq': 20, \n",
     "    'print': True  # Print states - Note: is much faster without\n",
     "}\n",
-    "(times, inputs, states, outputs, event_states) = batt.simulate_to(time_to_simulate_to, future_loading, first_output, **sim_config)"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "(times, inputs, states, outputs, event_states) = batt.simulate_to(time_to_simulate_to, future_loading, **sim_config)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We can also plot the results"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "event_states.plot(ylabel= 'SOC')\n",
     "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Instead of specifying a specific amount of time, we can also simulate until a threshold has been met using the simulate_to_threshold() method\n",
     "\n",
     "\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "options = { #configuration for this sim\n",
     "    'save_freq': 100, # Frequency at which results are saved (s)\n",
     "    'horizon': 5000 # Maximum time to simulate (s) - This is a cutoff. The simulation will end at this time, or when a threshold has been met, whichever is first\n",
     "    }\n",
-    "(times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, {'t': 18.95, 'v': 4.183}, **options)\n",
+    "(times, inputs, states, outputs, event_states) = batt.simulate_to_threshold(future_loading, **options)\n",
     "event_states.plot(ylabel='SOC')\n",
     "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Default is to simulate until any threshold is met, but we can also specify which event we are simulating to (any key from model.events) for multiple event models. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Building a new model using model generation\n",
     "The easiest way to build a new model is by using the model generation feature. This works for simple models.\n",
@@ -333,12 +304,13 @@
     "For this example, let's use a model of throwing an object directly into the air in a vacuum.\n",
     "\n",
     "First lets describe the model in a dictionary:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "keys = {\n",
     "    'inputs': [], # no inputs, no way to control\n",
@@ -354,63 +326,64 @@
     "        'impact' # Event- object has impacted the ground\n",
     "    ]\n",
     "}"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Here we have a description of what we're going to try to model, including any inputs, states, outputs, and predicted events. Now we can start defining the details of the model logic.\n",
     "\n",
     "First, we're going to define the initialization function. This is used to generate the first state."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "thrower_height = 1.83 # m\n",
     "throwing_speed = 40 # m/s\n",
-    "def initialize(u, z):\n",
+    "def initialize(u = None, z = None):\n",
+    "    # Note: First input and output are not needed here, so they're set to none\n",
     "    return {\n",
     "        'x': thrower_height, # Thrown, so initial altitude is height of thrower\n",
     "        'v': throwing_speed # Velocity at which the ball is thrown - this guy is an professional baseball pitcher\n",
     "        }"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, lets define the output equation- this translates from the state to any measurable parameters. In this case it's simple since we're saying the position ('x') state is directly measureable."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def output(x):\n",
     "    return {\n",
     "        'x': x['x']\n",
     "    }"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now, let's define the threshold_met and event_state equations. This defines when each event has occured, and how close you are to the event occuring, respectively. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def threshold_met(x):\n",
     "    return {\n",
@@ -425,83 +398,83 @@
     "        'impact': (x['v'] > 0) or max(x['x']/event_state.max_x,0) # 1 until falling begins, then it's fraction of height\n",
     "    }\n",
     "event_state.max_x = 0"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Note: strictly speaking the threshold_met equation isn't needed here- the default behavior is that the threshold is met when event state reaches 0. We define it here, because this implementation is more efficient. \n",
     "\n",
     "Finally, we define the meat of the model. There are two types of models: continuous and discrete. Discrete models are defined by some sort of transition equation x' = next_state(x, u, dt) while continuous models can be defined by the first derivative dx = dx(x, u). This model is continuous, so we define the equation dx:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def dx(x, u):\n",
     "    return {\n",
     "        'x': x['v'],\n",
     "        'v': -9.81 # Acceleration of gravity\n",
     "    }"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now we have all our pieces and can put it all together"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from prog_models import PrognosticsModel\n",
     "m = PrognosticsModel.generate_model(keys, initialize, output, event_state_eqn = event_state, threshold_eqn=threshold_met, dx_eqn=dx)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now that we have our model `m` we can use it just like the model in our previous example. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def future_load(t, x=None):\n",
     "        return {} # No loading\n",
     "event = 'impact'\n",
     "\n",
-    "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':thrower_height}, threshold_keys=[event], dt=0.005, save_freq=1)\n",
+    "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)\n",
     "\n",
     "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
     "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Building a new model - advanced\n",
     "For more advanced models, you can create a seperate class to defin the logic of the model. The functions are the same, just in a different format, and with added parameters. The model above could be defined using this approach like so:\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from prog_models import PrognosticsModel\n",
     "from math import inf\n",
@@ -542,7 +515,7 @@
     "        'v': (-299792458, 299792458)\n",
     "    }\n",
     "\n",
-    "    def initialize(self, u, z):\n",
+    "    def initialize(self, u=None, z=None):\n",
     "        self.max_x = 0.0\n",
     "        return {\n",
     "            'x': self.parameters['thrower_height'], # Thrown, so initial altitude is height of thrower\n",
@@ -575,20 +548,20 @@
     "            'falling': max(x['v']/self.parameters['throwing_speed'],0), # Throwing speed is max speed\n",
     "            'impact': (x['v'] > 0) or max(x['x']/self.max_x,0) # 1 until falling begins, then it's fraction of height\n",
     "        }"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now the model can be generated and used like any of the other provided models"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m = ThrownObject()\n",
     "\n",
@@ -596,26 +569,26 @@
     "        return {} # No loading\n",
     "event = 'impact'\n",
     "\n",
-    "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, {'x':m.parameters['thrower_height']}, threshold_keys=[event], dt=0.005, save_freq=1)\n",
+    "(times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)\n",
     "\n",
     "event_states.plot(ylabel= ['falling', 'impact'], compact= False)\n",
     "states.plot(ylabel= {'x': \"position (m)\", 'v': 'velocity (m/s)'}, compact= False)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Models can also include \"derived parameters\" (i.e., parameters that are derived from others). These can be set using the param_callbacks property. \n",
     "\n",
     "Let's extend the above model to include derived_parameters. Let's say that the throwing_speed was actually a function of thrower_height (i.e., a taller thrower would throw the ball faster). Here's how we would implement that"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Step 1: Define a function for the relationship between thrower_height and throwing_speed.\n",
     "def update_thrown_speed(params):\n",
@@ -627,20 +600,20 @@
     "ThrownObject.param_callbacks = {\n",
     "        'thrower_height': [update_thrown_speed]\n",
     "    }  # Tell the derived callbacks feature to call this function when thrower_height changes."
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Note: Usually we would define this menthod within the class. For this example, we're doing it separately to improve readability. Here's the feature in action"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "obj = ThrownObject()\n",
     "print(\"Default Settings:\\n\\tthrower_height: {}\\n\\tthowing_speed: {}\".format(obj.parameters['thrower_height'], obj.parameters['throwing_speed']))\n",
@@ -653,48 +626,48 @@
     "\n",
     "# Let's delete the callback so we can use the same model in the future:\n",
     "ThrownObject.param_callbacks = {}"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Note: State limits can be applied directly using the apply_limits function. For example:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x = {'x': -5, 'v': 3e8} # Too fast and below the ground\n",
     "x = obj.apply_limits(x)\n",
     "print(x)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Notice how the state was limited according to the model state limits"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Parameter Estimation\n",
     "Let's say we dont know the configuration of the above model. Instead, we have some data. We can use that data to estimate the parameters. \n",
     "\n",
     "First, we define the data:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "times = [0, 1, 2, 3, 4, 5, 6, 7, 8]\n",
     "inputs = [{}]*9\n",
@@ -709,73 +682,73 @@
     "    {'x': 41.51},\n",
     "    {'x': 7.91},\n",
     "]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, we identify which parameters will be optimized"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "keys = ['thrower_height', 'throwing_speed']"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Let's say we have a first guess that the thrower's height is 20m, silly I know"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m.parameters['thrower_height'] = 20"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Here's the state of our estimation with that assumption:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print('Model configuration before')\n",
     "for key in keys:\n",
     "    print(\"-\", key, m.parameters[key])\n",
     "print(' Error: ', m.calc_error(times, inputs, outputs, dt=1e-4))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Wow, that's a large error. \n",
     "\n",
     "Let's run the parameter estimation to see if we can do better"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m.estimate_params([(times, inputs, outputs)], keys, dt=0.01)\n",
     "\n",
@@ -784,31 +757,51 @@
     "for key in keys:\n",
     "    print(\"-\", key, m.parameters[key])\n",
     "print(' Error: ', m.calc_error(times, inputs, outputs, dt=1e-4))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Much better!"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Conclusion\n",
     "Thank you for trying out this tutorial. See the examples in the `examples/` folder for more details on how to use the package. Any questions can be directed to Chris Teubert (christopher.a.teubert@nasa.gov)"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "ff94885aa2d97705a9dae03869c2058fa855d1acd9df351499300343e2e591a2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.12 64-bit",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "metadata": {
+   "interpreter": {
+    "hash": "c1e35f02e3a88578371dd5b5d88a204463a98b2d7cd5222657e170520db47be1"
+   }
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Make initial output and input optional for some models, propagate changes to simulate_to and examples. 

For models that dont use output to estimate initial state, we shouldn't have to supply it. 

This enables using default first state in simulation. A feature requested in PaaS