### PR TITLE
Add equality comparison for models

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -249,6 +249,12 @@ class PrognosticsModel(ABC):
         except Exception:
             raise ProgModelTypeError('Model noise poorly configured')
 
+    def __eq__(self, other):
+        """
+        Check if two models are equal
+        """
+        return self.__class__ == other.__class__ and self.parameters == other.parameters
+    
     def __str__(self):
         return "{} Prognostics Model (Events: {})".format(type(self).__name__, self.events)
     

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -520,6 +520,7 @@ class TestModels(unittest.TestCase):
         m2 = pickle.load(open('model_test.pkl', 'rb'))
         isinstance(m2, MockProgModel)
         self.assertEqual(m.parameters['p1'], m2.parameters['p1'])
+        self.assertEqual(m, m2)
 
     def test_sim_to_thresh(self):
         m = MockProgModel(process_noise = 0.0)


### PR DESCRIPTION
Add ability to compare models using equality test (e.g, m1 == m2). Returns true if class type (e.g., BatteryCircuit or ThrownObject) and all configuration params are the same. 

Updated the pickle test to use equality comparison