### PR TITLE
Add warning when setting param that will be overwritten

### DIFF
--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -27,6 +27,16 @@ class TestBattery(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = batt.simulate_to(200, future_loading, {'t': 18.95, 'v': 4.183})
         self.assertEqual(BatteryElectroChem, BatteryElectroChemEODEOL)
 
+        # check warning raised when changing overwritten parameter
+        with self.assertWarns(UserWarning):
+            batt.parameters['Ro'] = 10
+        
+        with self.assertWarns(UserWarning):
+            batt.parameters['qMobile'] = 10
+
+        with self.assertWarns(UserWarning):
+            batt.parameters['tDiffusion'] = 10
+
     def test_battery_electrochem_EOD(self):
         batt = BatteryElectroChemEOD()
         (times, inputs, states, outputs, event_states) = batt.simulate_to(200, future_loading, {'t': 18.95, 'v': 4.183})

--- a/tests/test_centrifugal_pump.py
+++ b/tests/test_centrifugal_pump.py
@@ -150,6 +150,16 @@ class TestCentrifugalPump(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
         self.assertAlmostEqual(times[-1], 23891)
 
+        # Check warning when changing overwritten Parameters
+        with self.assertWarns(UserWarning):
+            pump.parameters['wA']  = 1e-2
+
+        with self.assertWarns(UserWarning):
+            pump.parameters['wRadial']  = 1e-2
+
+        with self.assertWarns(UserWarning):
+            pump.parameters['wThrust']  = 1e-10
+
     def test_centrifugal_pump(self):
         self.assertEqual(CentrifugalPump,CentrifugalPumpWithWear)
         # CentrifugalPump is alias for "with wear"

--- a/tests/test_pneumatic_valve.py
+++ b/tests/test_pneumatic_valve.py
@@ -178,6 +178,22 @@ class TestPneumaticValve(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, m.output(m.initialize(future_loading(0))), **config)# , 'save_freq': 60
         self.assertAlmostEqual(times[-1], 782.53, 0)
 
+        # Test warning when setting overwritten parameters
+        with self.assertWarns(UserWarning):
+            m.parameters['wb'] = 1
+
+        with self.assertWarns(UserWarning):
+            m.parameters['wi'] = 1
+
+        with self.assertWarns(UserWarning):
+            m.parameters['wk'] = 1
+
+        with self.assertWarns(UserWarning):
+            m.parameters['wr'] = 1
+
+        with self.assertWarns(UserWarning):
+            m.parameters['wt'] = 1
+
     def test_pneumatic_valve_base(self):
         # Test using PneumaticValveBase
         m = PneumaticValveBase(process_noise= 0)


### PR DESCRIPTION
Some parameters are overwritten in model extensions, adding warning that notifies user if they're setting a parameter for which this is true.

Also, removed 2 parameters that were unnecessarily being set in output method