### PR TITLE
Cache array sizes in prognostics_model and all children class models

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -33,7 +33,7 @@ class PrognosticsModelParameters(UserDict):
             self[key] = deepcopy(value)
 
         # Add class variables for length of inputs, outputs, events, state, and performance
-        self.lenStates = len(self.states)
+        self.n_states = len(self.states)
 
         # Add and run callbacks
         # Has to be done here so the base parameters are all set 

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -32,6 +32,9 @@ class PrognosticsModelParameters(UserDict):
             # Deepcopy is needed here to force copying when value is an object (e.g., dict)
             self[key] = deepcopy(value)
 
+        # Add class variables for length of inputs, outputs, events, state, and performance
+        self.lenStates = len(self.states)
+
         # Add and run callbacks
         # Has to be done here so the base parameters are all set 
         self.callbacks = callbacks


### PR DESCRIPTION
Member variables for caching array sizes of events, inputs, outputs, state, and performance.