### PR TITLE
Bug fix for LazySimResult not being pickle-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ ex.pickle
 
 .vscode/
 .DS_Store
+model_test.pkl

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -131,7 +131,7 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
         self.__data = None
 
     def __reduce__(self):
-        return (self.__class__, (self.fcn, self.times, self.states))
+        return (self.__class__.__base__, (self.times, self.data))
 
     def is_cached(self):
         """

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -130,6 +130,9 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
         self.states = deepcopy(states)
         self.__data = None
 
+    def __reduce__(self):
+        return (self.__class__, (self.fcn, self.times, self.states))
+
     def is_cached(self):
         """
         Returns:

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -38,7 +38,12 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result, result2)
 
     def test_pickle_lazy(self):
-        pass
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = LazySimResult(f, time, state)
     
     def test_cached_sim_result(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -43,11 +43,17 @@ class TestSimResult(unittest.TestCase):
         NUM_ELEMENTS = 5
         time = list(range(NUM_ELEMENTS))
         state = [i * 2.5 for i in range(NUM_ELEMENTS)]
-        result = LazySimResult(f, time, state)
+        lazy_result = LazySimResult(f, time, state) # Ordinary LazySimResult with f, time, state
+        sim_result = SimResult(time, state) # Ordinary SimResult with time,state
+
+        # Casting LazySimResult to  SimResult? or rather, building a new obj with manipulated time,state
+        converted_result = SimResult(lazy_result.times, lazy_result.data)
+        self.assertNotEqual(converted_result, sim_result) # converted is not the same as the original SimResult
 
         import pickle
-        with self.assertRaises(AttributeError):
-            pickle.dump(result, open('model_test.pkl', 'wb'))
+        pickle.dump(converted_result, open('model_test.pkl', 'wb'))
+        pickle_converted_result = pickle.load(open('model_test.pkl', 'rb'))
+        self.assertEqual(converted_result, pickle_converted_result)
         
     
     def test_cached_sim_result(self):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -44,6 +44,11 @@ class TestSimResult(unittest.TestCase):
         time = list(range(NUM_ELEMENTS))
         state = [i * 2.5 for i in range(NUM_ELEMENTS)]
         result = LazySimResult(f, time, state)
+
+        import pickle
+        with self.assertRaises(AttributeError):
+            pickle.dump(result, open('model_test.pkl', 'wb'))
+        
     
     def test_cached_sim_result(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -47,14 +47,13 @@ class TestSimResult(unittest.TestCase):
         sim_result = SimResult(time, state) # Ordinary SimResult with time,state
 
         # Casting LazySimResult to  SimResult? or rather, building a new obj with manipulated time,state
-        converted_result = SimResult(lazy_result.times, lazy_result.data)
-        self.assertNotEqual(converted_result, sim_result) # converted is not the same as the original SimResult
+        converted_lazy_result = SimResult(lazy_result.times, lazy_result.data)
+        self.assertNotEqual(sim_result, converted_lazy_result) # converted is not the same as the original SimResult
 
-        import pickle
-        pickle.dump(converted_result, open('model_test.pkl', 'wb'))
+        import pickle # try pickle'ing
+        pickle.dump(converted_lazy_result, open('model_test.pkl', 'wb'))
         pickle_converted_result = pickle.load(open('model_test.pkl', 'rb'))
-        self.assertEqual(converted_result, pickle_converted_result)
-        
+        self.assertEqual(converted_lazy_result, pickle_converted_result)
     
     def test_cached_sim_result(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -46,7 +46,6 @@ class TestSimResult(unittest.TestCase):
         lazy_result = LazySimResult(f, time, state) # Ordinary LazySimResult with f, time, state
         sim_result = SimResult(time, state) # Ordinary SimResult with time,state
 
-        # Casting LazySimResult to  SimResult? or rather, building a new obj with manipulated time,state
         converted_lazy_result = SimResult(lazy_result.times, lazy_result.data)
         self.assertNotEqual(sim_result, converted_lazy_result) # converted is not the same as the original SimResult
 

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -51,7 +51,7 @@ class TestSimResult(unittest.TestCase):
         self.assertNotEqual(sim_result, converted_lazy_result) # converted is not the same as the original SimResult
 
         import pickle # try pickle'ing
-        pickle.dump(converted_lazy_result, open('model_test.pkl', 'wb'))
+        pickle.dump(lazy_result, open('model_test.pkl', 'wb'))
         pickle_converted_result = pickle.load(open('model_test.pkl', 'rb'))
         self.assertEqual(converted_lazy_result, pickle_converted_result)
     

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -36,6 +36,9 @@ class TestSimResult(unittest.TestCase):
         pickle.dump(result, open('model_test.pkl', 'wb'))
         result2 = pickle.load(open('model_test.pkl', 'rb'))
         self.assertEqual(result, result2)
+
+    def test_pickle_lazy(self):
+        pass
     
     def test_cached_sim_result(self):
         def f(x):


### PR DESCRIPTION
Introducing unittesting and bug fixes to correct LazySimResult not being pickle-able due to its function member variable.