### PR TITLE
Implementation of LazySimResult to_SimResult() method

### DIFF
--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -202,8 +202,8 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
             self.states.pop(target_index)
             self.__data.pop(target_index)
 
-    def to_SimResult(self, other : SimResult) -> SimResult:
-        pass
+    def to_SimResult(self) -> SimResult:
+        return SimResult(self.times, self.data)
 
     @property
     def data(self):

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -202,6 +202,9 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
             self.states.pop(target_index)
             self.__data.pop(target_index)
 
+    def to_SimResult(self, other : SimResult) -> SimResult:
+        pass
+
     @property
     def data(self):
         """

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -202,7 +202,7 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
             self.states.pop(target_index)
             self.__data.pop(target_index)
 
-    def to_SimResult(self) -> SimResult:
+    def to_simresult(self) -> SimResult:
         return SimResult(self.times, self.data)
 
     @property

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -395,7 +395,21 @@ class TestSimResult(unittest.TestCase):
         self.assertRaises(NotImplementedError, result.insert)
         self.assertRaises(NotImplementedError, result.reverse)
 
+    def test_lazy_to_SimResult(self):
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = LazySimResult(f, time, state)
 
+        converted_result = result.to_SimResult()
+        self.assertTrue(isinstance(converted_result, SimResult)) # Ensure type is SimResult
+        self.assertEqual(converted_result.times, result.times) # Compare to original LazySimResult
+        self.assertEqual(converted_result.data, result.data)
+        self.assertEqual(converted_result.times, [0, 1, 2, 3, 4]) # Compare to expected values
+        self.assertEqual(converted_result.data, [0.0, 5.0, 10.0, 15.0, 20.0])
+        
 # This allows the module to be executed directly
 def run_tests():
     unittest.main()

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -403,7 +403,7 @@ class TestSimResult(unittest.TestCase):
         state = [i * 2.5 for i in range(NUM_ELEMENTS)]
         result = LazySimResult(f, time, state)
 
-        converted_result = result.to_SimResult()
+        converted_result = result.to_simresult()
         self.assertTrue(isinstance(converted_result, SimResult)) # Ensure type is SimResult
         self.assertEqual(converted_result.times, result.times) # Compare to original LazySimResult
         self.assertEqual(converted_result.data, result.data)


### PR DESCRIPTION
LazySimResult method to convert current object to a SimResult object