### PR TITLE
Implementation of LazySimResult extending a SimResult object

### DIFF
--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -158,15 +158,21 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
 
     def extend(self, other):
         """
-        Extend the LazySimResult with another LazySimResult or SimResult object
+        Extend the LazySimResult with another LazySimResult object
+        Raise ValueError if SimResult is passed
 
         Args:
-            other (SimResult/LazySimResult)
+            other (LazySimResult)
 
         """
-        self.times.extend(deepcopy(other.times))  # lgtm [py/modification-of-default-value]
-        self.__data = None
-        self.states.extend(deepcopy(other.states))  # lgtm [py/modification-of-default-value]
+        if (isinstance(other, self.__class__)):
+            self.times.extend(deepcopy(other.times))  # lgtm [py/modification-of-default-value]
+            self.__data = None
+            self.states.extend(deepcopy(other.states))  # lgtm [py/modification-of-default-value]
+        elif (isinstance(other, SimResult)):
+            raise ValueError(f"ValueError: {self.__class__} cannot be extended by SimResult. First convert to SimResult using to_simresult() method.")
+        else:
+            raise ValueError(f"ValueError: Argument must be of type {self.__class__}.")
 
     def pop(self, index : int = -1):
         """Remove an element. If data hasn't been cached, remove the state - so it wont be calculated

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -149,11 +149,21 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
         return self.__data is not None
 
     def clear(self):
+        """
+        Clears the times, states, and data cache for a LazySimResult object
+        """
         self.times = []
         self.__data = None
         self.states = []
 
     def extend(self, other):
+        """
+        Extend the LazySimResult with another LazySimResult or SimResult object
+
+        Args:
+            other (SimResult/LazySimResult)
+
+        """
         self.times.extend(deepcopy(other.times))  # lgtm [py/modification-of-default-value]
         self.__data = None
         self.states.extend(deepcopy(other.states))  # lgtm [py/modification-of-default-value]

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -44,10 +44,10 @@ class SimResult(UserList):
 
     def extend(self, other) -> None:
         """
-        Extend the SimResult with another SimResult
+        Extend the SimResult with another SimResult or LazySimResult object
 
         Args:
-            other (SimResult)
+            other (SimResult/LazySimResult)
 
         """
         self.times.extend(other.times)

--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -1,7 +1,5 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 from collections import UserList
-
-from numpy import isin
 from .visualize import plot_timeseries
 from copy import deepcopy
 

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -294,6 +294,39 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result.data, [0.0, 5.0, 10.0, 15.0, 20.0, 0, 25, 50, 75, 100, 125, 150, 175, 200, 225])
         self.assertEqual(result.states, [0.0, 2.5, 5.0, 7.5, 10.0, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
 
+    def test_lazy_extend_cache(self):
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result1 = LazySimResult(f, time, state)
+        result2 = LazySimResult(f, time, state)
+
+        # Case 1
+        result1.extend(result2)
+        self.assertFalse(result1.is_cached()) # False
+        
+        # Case 2
+        result1 = LazySimResult(f, time, state) # Reset result1
+        store_test_data = result1.data # Access result1 data
+        result1.extend(result2) 
+        self.assertFalse(result1.is_cached()) # False
+
+        # Case 3
+        result1 = LazySimResult(f, time, state) # Reset result1
+        store_test_data = result2.data # Access result2 data
+        result1.extend(result2) 
+        self.assertFalse(result1.is_cached()) # False
+
+        # Case 4
+        result1 = LazySimResult(f, time, state) # Reset result1
+        result2 = LazySimResult(f, time, state) # Reset result2
+        store_test_data1 = result1.data # Access result1 data
+        store_test_data2 = result2.data # Access result2 data
+        result1.extend(result2) 
+        self.assertTrue(result1.is_cached()) # True
+
     def test_lazy_extend_error(self):
         def f(x):
             return x * 2

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -395,7 +395,7 @@ class TestSimResult(unittest.TestCase):
         self.assertRaises(NotImplementedError, result.insert)
         self.assertRaises(NotImplementedError, result.reverse)
 
-    def test_lazy_to_SimResult(self):
+    def test_lazy_to_simresult(self):
         def f(x):
             return x * 2
         NUM_ELEMENTS = 5

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -72,7 +72,6 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result2.times, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0]) # Assert data is correct before extending
         self.assertEqual(result2.data, [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
-        
         result.extend(result2) # Extend result with result2
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
@@ -289,6 +288,27 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) # Assert data is correct after extending
         self.assertEqual(result.data, [0.0, 5.0, 10.0, 15.0, 20.0, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         self.assertEqual(result.states, [0.0, 2.5, 5.0, 7.5, 10.0, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
+
+    def test_lazy_extended_by_simresult(self):
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 10 
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result2 = LazySimResult(f, time, state) # Creating one LazySimResult object
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = SimResult(time, state) # Creating one SimResult object
+
+        self.assertEqual(result.times, [0, 1, 2, 3, 4])
+        self.assertEqual(result2.times, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0]) # Assert data is correct before extending
+        self.assertEqual(result2.data, [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
+        result.extend(result2) # Extend result with result2
+        self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
+
 
     def test_lazy_pop(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -1,6 +1,7 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
 import unittest
+from prog_models import sim_result
 
 from prog_models.sim_result import SimResult, LazySimResult
 
@@ -289,26 +290,25 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result.data, [0.0, 5.0, 10.0, 15.0, 20.0, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         self.assertEqual(result.states, [0.0, 2.5, 5.0, 7.5, 10.0, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
 
-    def test_lazy_extended_by_simresult(self):
+    def test_lazy_extend_error(self):
         def f(x):
             return x * 2
-        NUM_ELEMENTS = 10 
-        time = list(range(NUM_ELEMENTS))
-        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
-        result2 = LazySimResult(f, time, state) # Creating one LazySimResult object
         NUM_ELEMENTS = 5
         time = list(range(NUM_ELEMENTS))
         state = [i * 2.5 for i in range(NUM_ELEMENTS)]
-        result = SimResult(time, state) # Creating one SimResult object
+        result = LazySimResult(f, time, state)
 
-        self.assertEqual(result.times, [0, 1, 2, 3, 4])
-        self.assertEqual(result2.times, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0]) # Assert data is correct before extending
-        self.assertEqual(result2.data, [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
-        result.extend(result2) # Extend result with result2
-        self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
+        NUM_ELEMENTS = 5
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        sim_result = SimResult(time, state)
 
+        self.assertRaises(ValueError, result.extend, sim_result) # Passing a SimResult to LazySimResult's extend
+        self.assertRaises(ValueError, result.extend, 0) # Passing non-LazySimResult types to extend method
+        self.assertRaises(ValueError, result.extend, [0,1])
+        self.assertRaises(ValueError, result.extend, {})
+        self.assertRaises(ValueError, result.extend, set())
+        self.assertRaises(ValueError, result.extend, 1.5)
 
     def test_lazy_pop(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -65,17 +65,17 @@ class TestSimResult(unittest.TestCase):
             return x * 2
         NUM_ELEMENTS = 10
         time = list(range(NUM_ELEMENTS))
-        state = [i * 10.0 for i in range(NUM_ELEMENTS)]
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
         result2 = LazySimResult(f, time, state) # Creating one LazySimResult object
 
         self.assertEqual(result.times, [0, 1, 2, 3, 4])
         self.assertEqual(result2.times, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0]) # Assert data is correct before extending
-        self.assertEqual(result2.data, [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
+        self.assertEqual(result2.data, [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
         
         result.extend(result2) # Extend result with result2
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
+        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
 
     def test_pickle_lazy(self):
         def f(x):

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -56,6 +56,27 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
 
+    def test_extended_by_lazy(self):
+        NUM_ELEMENTS = 5 
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 2.5 for i in range(NUM_ELEMENTS)]
+        result = SimResult(time, state) # Creating one SimResult object
+        def f(x):
+            return x * 2
+        NUM_ELEMENTS = 10
+        time = list(range(NUM_ELEMENTS))
+        state = [i * 10.0 for i in range(NUM_ELEMENTS)]
+        result2 = LazySimResult(f, time, state) # Creating one LazySimResult object
+
+        self.assertEqual(result.times, [0, 1, 2, 3, 4])
+        self.assertEqual(result2.times, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0]) # Assert data is correct before extending
+        self.assertEqual(result2.data, [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
+        
+        result.extend(result2) # Extend result with result2
+        self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
+
     def test_pickle_lazy(self):
         def f(x):
             return x * 2

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -57,6 +57,12 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(result.data, [0.0, 2.5, 5.0, 7.5, 10.0, 0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0])
 
+        self.assertRaises(ValueError, result.extend, 0) # Passing non-LazySimResult types to extend method
+        self.assertRaises(ValueError, result.extend, [0,1])
+        self.assertRaises(ValueError, result.extend, {})
+        self.assertRaises(ValueError, result.extend, set())
+        self.assertRaises(ValueError, result.extend, 1.5)
+
     def test_extended_by_lazy(self):
         NUM_ELEMENTS = 5 
         time = list(range(NUM_ELEMENTS))
@@ -283,11 +289,9 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(result2.data, [0, 25, 50, 75, 100, 125, 150, 175, 200, 225])
         self.assertEqual(result2.states, [0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
 
-        self.assertTrue(result.is_cached())
         result.extend(result2)
-        self.assertFalse(result.is_cached())
         self.assertEqual(result.times, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) # Assert data is correct after extending
-        self.assertEqual(result.data, [0.0, 5.0, 10.0, 15.0, 20.0, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        self.assertEqual(result.data, [0.0, 5.0, 10.0, 15.0, 20.0, 0, 25, 50, 75, 100, 125, 150, 175, 200, 225])
         self.assertEqual(result.states, [0.0, 2.5, 5.0, 7.5, 10.0, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
 
     def test_lazy_extend_error(self):


### PR DESCRIPTION
Enable SimResult to be extended by LazySimResult.

If possible, extend LazySimResult with SimResult. If not, add check to prevent trying.

