### PR TITLE
Feature for simulate_to* to return namedtuples instead of basic tuples

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -79,10 +79,10 @@ def run_example():
     m = MyBatt()
 
     # 2b: Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, threshold_keys=['EOD'], print = True)
+    simulated_results = m.simulate_to_threshold(future_loading, threshold_keys=['EOD'], print = True)
 
     # 2c: Plot results
-    event_states.plot()
+    simulated_results.event_states.plot()
     import matplotlib.pyplot as plt
     plt.show()
 

--- a/examples/future_loading.py
+++ b/examples/future_loading.py
@@ -31,11 +31,11 @@ def run_example():
         'save_freq': 100,  # Frequency at which results are saved
         'dt': 2  # Timestep
     }
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
+    simulated_results = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
-    inputs.plot(ylabel = 'Variable Load Current (amps)')
-    event_states.plot(ylabel = 'Variable Load Event State')
+    simulated_results.inputs.plot(ylabel = 'Variable Load Current (amps)')
+    simulated_results.event_states.plot(ylabel = 'Variable Load Event State')
 
     ## Example 2: Moving Average loading 
     # This is useful in cases where you are running reoccuring simulations, and are measuring the actual load on the system, 
@@ -67,11 +67,11 @@ def run_example():
     
     # Now the future_loading eqn is setup to use the moving average of whats been seen
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
+    simulated_results = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
-    inputs.plot(ylabel = 'Moving Average Current (amps)')
-    event_states.plot(ylabel = 'Moving Average Event State')
+    simulated_results.inputs.plot(ylabel = 'Moving Average Current (amps)')
+    simulated_results.event_states.plot(ylabel = 'Moving Average Event State')
 
     # In this case, this estimate is wrong because loading will not be steady, but at least it would give you an approximation.
 
@@ -97,11 +97,11 @@ def run_example():
     future_loading.std = 0.2
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
+    simulated_results = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
-    inputs.plot(ylabel = 'Variable Gaussian Current (amps)')
-    event_states.plot(ylabel = 'Variable Gaussian Event State')
+    simulated_results.inputs.plot(ylabel = 'Variable Gaussian Current (amps)')
+    simulated_results.event_states.plot(ylabel = 'Variable Gaussian Event State')
 
     # Example 4: Gaussian- increasing with time
     # For this we're using moving average. This is realistic because the further out from current time you get, 
@@ -136,11 +136,11 @@ def run_example():
         moving_avg({'i': load})
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
+    simulated_results = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
-    inputs.plot(ylabel = 'Moving Average Current (amps)')
-    event_states.plot(ylabel = 'Moving Average Event State')
+    simulated_results.inputs.plot(ylabel = 'Moving Average Current (amps)')
+    simulated_results.event_states.plot(ylabel = 'Moving Average Event State')
     
     # In this example future_loading.t has to be updated with current time before each prediction.
     
@@ -158,11 +158,11 @@ def run_example():
     future_loading.start = 0.5
 
     # Simulate to threshold
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_loading, **options)
+    simulated_results = m.simulate_to_threshold(future_loading, **options)
 
     # Now lets plot the inputs and event_states
-    inputs.plot(ylabel = 'Moving Average Current (amps)')
-    event_states.plot(ylabel = 'Moving Average Event State')
+    simulated_results.inputs.plot(ylabel = 'Moving Average Current (amps)')
+    simulated_results.event_states.plot(ylabel = 'Moving Average Event State')
 
     # In this example future_loading.t has to be updated with current time before each prediction.
 

--- a/examples/model_gen.py
+++ b/examples/model_gen.py
@@ -74,10 +74,10 @@ def run_example():
 
     # Step 8: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt = 0.005, save_freq=1, print = True)
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt = 0.005, save_freq=1, print = True)
     
     # Print flight time
-    print('The object hit the ground in {} seconds'.format(round(times[-1],2)))
+    print('The object hit the ground in {} seconds'.format(round(simulated_results.times[-1],2)))
 
 # This allows the module to be executed directly 
 if __name__=='__main__':

--- a/examples/new_model.py
+++ b/examples/new_model.py
@@ -74,10 +74,10 @@ def run_example():
 
     # Step 3: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, print = True)
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, print = True)
     
     # Print flight time
-    print('The object hit the ground in {} seconds'.format(round(times[-1],2)))
+    print('The object hit the ground in {} seconds'.format(round(simulated_results.times[-1],2)))
 
     # OK, now lets compare performance on different heavenly bodies. 
     # This requires that we update the cofiguration
@@ -85,26 +85,26 @@ def run_example():
 
     # The first way to change the configuration is to pass in your desired config into construction of the model
     m = ThrownObject(g = grav_moon)
-    (times_moon, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    simulated_moon_results = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     grav_mars = -3.711
     # You can also update the parameters after it's constructed
     m.parameters['g'] = grav_mars
-    (times_mars, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    simulated_mars_results = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     grav_venus = -8.87
     m.parameters['g'] = grav_venus
-    (times_venus, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
+    simulated_venus_results = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':0.005, 'save_freq':1})
 
     print('Time to hit the ground: ')
-    print('\tvenus: {}s'.format(round(times_venus[-1],2)))
-    print('\tearth: {}s'.format(round(times[-1],2)))
-    print('\tmars: {}s'.format(round(times_mars[-1],2)))
-    print('\tmoon: {}s'.format(round(times_moon[-1],2)))
+    print('\tvenus: {}s'.format(round(simulated_venus_results.times[-1],2)))
+    print('\tearth: {}s'.format(round(simulated_results.times[-1],2)))
+    print('\tmars: {}s'.format(round(simulated_mars_results.times[-1],2)))
+    print('\tmoon: {}s'.format(round(simulated_moon_results.times[-1],2)))
 
     # We can also simulate until any event is met by neglecting the threshold_keys argument
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, options={'dt':0.005, 'save_freq':1})
-    threshs_met = m.threshold_met(states[-1])
+    simulated_results = m.simulate_to_threshold(future_load, options={'dt':0.005, 'save_freq':1})
+    threshs_met = m.threshold_met(simulated_results.states[-1])
     for (key, met) in threshs_met.items():
         if met:
             event_occured = key

--- a/examples/noise.py
+++ b/examples/noise.py
@@ -16,26 +16,26 @@ def run_example():
     # Ex1: No noise
     process_noise = 0
     m = ThrownObject(process_noise = process_noise)
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     print('Example without noise')
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
     # Ex2: with noise - same noise applied to every state
     process_noise = 0.5
     m = ThrownObject(process_noise = process_noise)  # Noise with a std of 0.5 to every state
     print('\nExample without same noise for every state')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
     # Ex3: noise- more noise on position than velocity
     process_noise = {'x': 0.25, 'v': 0.75}
     m = ThrownObject(process_noise = process_noise) 
     print('\nExample with more noise on position than velocity')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
     # Ex4: noise- Ex3 but uniform
     process_noise = {'x': 0.25, 'v': 0.75}
@@ -43,9 +43,9 @@ def run_example():
     model_config = {'process_noise_dist': process_noise_dist, 'process_noise': process_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with more uniform noise')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
     # Ex5: noise- Ex3 but triangle
     process_noise = {'x': 0.25, 'v': 0.75}
@@ -53,9 +53,9 @@ def run_example():
     model_config = {'process_noise_dist': process_noise_dist, 'process_noise': process_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with triangular process noise')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
     # Ex6: Measurement noise
     # Everything we've done with process noise, we can also do with measurement noise.
@@ -65,10 +65,10 @@ def run_example():
     model_config = {'measurement_noise_dist': measurement_noise_dist, 'measurement_noise': measurement_noise}
     m = ThrownObject(**model_config) 
     print('\nExample with measurement noise')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- outputs: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, outputs)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- outputs: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.outputs)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
     print(' note the output is sometimes not the same as state- that is the measurement noise')
 
     # Ex7: OK, now for something a little more complicated. Let's try proportional noise on v only (more variation when it's going faster)
@@ -81,9 +81,9 @@ def run_example():
     model_config = {'process_noise': apply_proportional_process_noise}
     m = ThrownObject(**model_config)
     print('\nExample with proportional noise on velocity')
-    (times, _, states, outputs, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
-    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(times, states)])) 
-    print('\t- impact time: {}s'.format(times[-1]))
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    print('\t- states: {}'.format(['{}s: {}'.format(round(t,2), x) for (t,x) in zip(simulated_results.times, simulated_results.states)])) 
+    print('\t- impact time: {}s'.format(simulated_results.times[-1]))
 
 # This allows the module to be executed directly 
 if __name__=='__main__':

--- a/examples/sensitivity.py
+++ b/examples/sensitivity.py
@@ -26,8 +26,8 @@ def run_example():
     eods = np.empty(len(thrower_height_range))
     for (i, thrower_height) in zip(range(len(thrower_height_range)), thrower_height_range):
         m.parameters['thrower_height'] = thrower_height
-        (times, _, _, _, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt =1e-3, save_freq =10)
-        eods[i] = times[-1]
+        simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt =1e-3, save_freq =10)
+        eods[i] = simulated_results.times[-1]
 
     # Step 5: Analysis
     print('For a reasonable range of heights, impact time is between {} and {}'.format(round(eods[0],3), round(eods[-1],3)))
@@ -40,8 +40,8 @@ def run_example():
     eods = np.empty(len(throw_speed_range))
     for (i, throw_speed) in zip(range(len(throw_speed_range)), throw_speed_range):
         m.parameters['throwing_speed'] = throw_speed
-        (times, _, _, _, _) = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':1e-3, 'save_freq':10})
-        eods[i] = times[-1]
+        simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], options={'dt':1e-3, 'save_freq':10})
+        eods[i] = simulated_results.times[-1]
 
     print('\nFor a reasonable range of throwing speeds, impact time is between {} and {}'.format(round(eods[0],3), round(eods[-1],3)))
     sensitivity = (eods[-1]-eods[0])/(throw_speed_range[-1] - throw_speed_range[0])

--- a/examples/sim_pump.py
+++ b/examples/sim_pump.py
@@ -40,17 +40,17 @@ def run_example():
         'save_freq': 1e3,
         'print': True
     }
-    (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, first_output, **config)
+    simulated_results = pump.simulate_to_threshold(future_loading, first_output, **config)
 
     # Step 4: Plot Results
     from prog_models.visualize import plot_timeseries
-    plot_timeseries(times, inputs, options={'compact': False, 'title': 'Inputs',
+    plot_timeseries(simulated_results.times, simulated_results.inputs, options={'compact': False, 'title': 'Inputs',
                                                     'xlabel': 'time', 'ylabel':{lbl: lbl for lbl in pump.inputs}})
-    plot_timeseries(times, states, options={'compact': False, 'title': 'States', 'xlabel': 'time', 'ylabel': ''})
-    plot_timeseries(times, outputs, options={'compact': False, 'title': 'Outputs', 'xlabel': 'time', 'ylabel': ''})
-    plot_timeseries(times, event_states, options={'compact': False, 'title': 'Events', 'xlabel': 'time', 'ylabel': ''})
-    thresholds_met = [pump.threshold_met(x) for x in states]
-    plot_timeseries(times, thresholds_met, options={'compact': True, 'title': 'Events', 'xlabel': 'time', 'ylabel': ''}, legend = {'display': True})
+    plot_timeseries(simulated_results.times, simulated_results.states, options={'compact': False, 'title': 'States', 'xlabel': 'time', 'ylabel': ''})
+    plot_timeseries(simulated_results.times, simulated_results.outputs, options={'compact': False, 'title': 'Outputs', 'xlabel': 'time', 'ylabel': ''})
+    plot_timeseries(simulated_results.times, simulated_results.event_states, options={'compact': False, 'title': 'Events', 'xlabel': 'time', 'ylabel': ''})
+    thresholds_met = [pump.threshold_met(x) for x in simulated_results.states]
+    plot_timeseries(simulated_results.times, thresholds_met, options={'compact': True, 'title': 'Events', 'xlabel': 'time', 'ylabel': ''}, legend = {'display': True})
 
     import matplotlib.pyplot as plt    
     plt.show()

--- a/examples/state_limits.py
+++ b/examples/state_limits.py
@@ -28,11 +28,11 @@ def run_example():
 
     # Step 3: Simulate to impact
     event = 'impact'
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1)
     
     # Print states
     print('Example 1')
-    for i, state in enumerate(states):
+    for i, state in enumerate(simulated_results.states):
         print('State ', i, ': ', state)
     print()
 
@@ -40,11 +40,11 @@ def run_example():
     x0 = m.initialize(u = {}, z = {})
     x0['x'] = -1
 
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, x = x0)
+    simulated_results = m.simulate_to_threshold(future_load, threshold_keys=[event], dt=0.005, save_freq=1, x = x0)
 
     # Print states
     print('Example 2')
-    for i, state in enumerate(states):
+    for i, state in enumerate(simulated_results.states):
         print('State ', i, ': ', state)
     print()
 

--- a/examples/visualize.py
+++ b/examples/visualize.py
@@ -20,18 +20,18 @@ def run_example():
     # Step 3: Simulate to impact
     event = 'impact'
     options={'dt':0.005, 'save_freq':1}
-    (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(future_load,
+    simulated_results = m.simulate_to_threshold(future_load,
                                                                              threshold_keys=[event], 
                                                                              **options)
     
 
     # Display states
     # ==============
-    plot_timeseries(times, states, 
+    plot_timeseries(simulated_results.times, simulated_results.states, 
                           options = {'compact': False, 'suptitle': 'state evolution', 'title': True,
                                      'xlabel': 'time', 'ylabel': {'x': 'position', 'v': 'velocity'}, 'display_labels': 'minimal'},
                           legend  = {'display': True, 'display_at_subplot': 'all'} )
-    plot_timeseries(times, states, options = {'compact': True, 'suptitle': 'state evolution', 'title': 'example title',
+    plot_timeseries(simulated_results.times, simulated_results.states, options = {'compact': True, 'suptitle': 'state evolution', 'title': 'example title',
                                                     'xlabel': 'time', 'ylabel':'position'})
     plt.show()
 

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -210,7 +210,8 @@ class PrognosticsModel(ABC):
     events = []       # Identifiers for each event
     param_callbacks = {}  # Callbacks for derived parameters
 
-    observables_keys = performance_metric_keys # for backwards compatability
+    observables_keys = performance_metric_keys # for backwards compatability        
+    SimulationResults = namedtuple('SimulationResults', ['times', 'inputs', 'states', 'outputs', 'event_states'])
 
     def __init__(self, **kwargs):
         if not hasattr(self, 'inputs'):
@@ -955,8 +956,7 @@ class PrognosticsModel(ABC):
             saved_outputs = SimResult(saved_times, saved_outputs)
             saved_event_states = SimResult(saved_times, saved_event_states)
         
-        Simulation = namedtuple('Simulation', ['times', 'inputs', 'states', 'outputs', 'event_states'])
-        return Simulation(
+        return self.SimulationResults(
             saved_times, 
             SimResult(saved_times, saved_inputs), 
             SimResult(saved_times, saved_states), 

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -7,7 +7,7 @@ from numbers import Number
 import numpy as np
 from copy import deepcopy
 from warnings import warn
-from collections import UserDict, abc
+from collections import UserDict, abc, namedtuple
 import types
 from array import array
 from .sim_result import SimResult, LazySimResult
@@ -672,7 +672,7 @@ class PrognosticsModel(ABC):
         return {key: event_state <= 0 \
             for (key, event_state) in self.event_state(x).items()} 
 
-    def simulate_to(self, time, future_loading_eqn, first_output = None, **kwargs) -> tuple:
+    def simulate_to(self, time, future_loading_eqn, first_output = None, **kwargs) -> namedtuple:
         """
         Simulate prognostics model for a given number of seconds
 
@@ -736,7 +736,7 @@ class PrognosticsModel(ABC):
 
         return self.simulate_to_threshold(future_loading_eqn, first_output, **kwargs)
  
-    def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs) -> tuple:
+    def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs) -> namedtuple:
         """
         Simulate prognostics model until any or specified threshold(s) have been met
 
@@ -955,7 +955,8 @@ class PrognosticsModel(ABC):
             saved_outputs = SimResult(saved_times, saved_outputs)
             saved_event_states = SimResult(saved_times, saved_event_states)
         
-        return (
+        Simulation = namedtuple('Simulation', ['times', 'inputs', 'states', 'outputs', 'event_states'])
+        return Simulation(
             saved_times, 
             SimResult(saved_times, saved_inputs), 
             SimResult(saved_times, saved_states), 

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -576,6 +576,18 @@ class TestModels(unittest.TestCase):
 
         (times, inputs, states, outputs, event_states) = m.simulate_to(6, load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
         self.assertAlmostEqual(times[-1], 6.0, 5)
+
+    def test_sim_namedtuple_access(self):
+        m = MockProgModel(process_noise = 0.0)
+        def load(t, x=None):
+            return {'i1': 1, 'i2': 2.1}
+        (times, inputs, states, outputs, event_states) = m.simulate_to(6, load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
+        named_results = m.simulate_to(6, load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
+        self.assertEquals(times, named_results.times)
+        self.assertEquals(inputs, named_results.inputs)
+        self.assertEquals(states, named_results.states)
+        self.assertEquals(outputs, named_results.outputs)
+        self.assertEquals(event_states, named_results.event_states)
         
     def test_next_time_fcn(self):
         m = MockProgModel(process_noise = 0.0)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,6 +1,8 @@
 # Copyright © 2020 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
 import unittest
+
+from pandas import array
 from prog_models.models import BatteryCircuit, BatteryElectroChem, BatteryElectroChemEOL, BatteryElectroChemEOD, BatteryElectroChemEODEOL
 
 def future_loading(t, x=None):
@@ -44,6 +46,16 @@ class TestBattery(unittest.TestCase):
     def test_battery_electrochem_EOL(self):
         batt = BatteryElectroChemEOL()
         (times, inputs, states, outputs, event_states) = batt.simulate_to(200, future_loading, {'t': 18.95, 'v': 4.183})
+
+    def test_batt_namedtuple_access(self):
+        batt = BatteryElectroChemEOL()
+        named_results = batt.simulate_to(200, future_loading, {'t': 18.95, 'v': 4.183})
+        # Can't test for equality, sim values different each run. Test assignment
+        times = named_results.times
+        inputs = named_results.inputs
+        states = named_results.states
+        outputs = named_results.outputs
+        event_states = named_results.event_states
 
 # This allows the module to be executed directly
 def run_tests():

--- a/tests/test_centrifugal_pump.py
+++ b/tests/test_centrifugal_pump.py
@@ -164,6 +164,50 @@ class TestCentrifugalPump(unittest.TestCase):
         self.assertEqual(CentrifugalPump,CentrifugalPumpWithWear)
         # CentrifugalPump is alias for "with wear"
 
+    def test_centrifugal_pump_namedtuple_access(self):
+        pump = CentrifugalPumpWithWear(process_noise= 0)
+
+        cycle_time = 3600
+        def future_loading(t, x=None):
+            t = t % cycle_time
+            if t < cycle_time/2.0:
+                V = 471.2389
+            elif t < cycle_time/2 + 100:
+                V = 471.2389 + (t-cycle_time/2)
+            elif t < cycle_time - 100:
+                V = 571.2389
+            else:
+                V = 471.2398 - (t-cycle_time)
+
+            return {
+                'Tamb': 290,
+                'V': V,
+                'pdisch': 928654, 
+                'psuc': 239179, 
+                'wsync': V * 0.8
+            }
+        x0 = pump.initialize(future_loading(0))
+        x0_test = {
+            'w': 376.991118431,
+            'wA': 0.00,
+            'wRadial': 0.0,
+            'wThrust': 0,
+            'rThrust': 1.4e-6,
+            'rRadial': 1.8e-6,
+            'Tt': 290,
+            'Tr': 290,
+            'To': 290,
+            'Q': 0.0,
+            'A': 12.7084,
+            'QLeak':  -8.303463132934355e-08
+        }
+        # named_results = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
+        # times = named_results.times
+        # inputs = named_results.inputs
+        # states = named_results.states
+        # outputs = named_results.outputs
+        # event_states = named_results.event_states
+
 # This allows the module to be executed directly
 def run_tests():
     unittest.main()

--- a/tests/test_centrifugal_pump.py
+++ b/tests/test_centrifugal_pump.py
@@ -201,12 +201,40 @@ class TestCentrifugalPump(unittest.TestCase):
             'A': 12.7084,
             'QLeak':  -8.303463132934355e-08
         }
-        # named_results = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
-        # times = named_results.times
-        # inputs = named_results.inputs
-        # states = named_results.states
-        # outputs = named_results.outputs
-        # event_states = named_results.event_states
+        
+        x = pump.next_state(x0, future_loading(0), 1)
+        x_test = {
+            'w': 372.68973081274,
+            'Q': 0.017417462,
+            'Tt': 290.027256332,
+            'Tr': 290.1065917275,
+            'To': 290,
+            'A': 12.7084,
+            'rThrust': 1.4e-6,
+            'rRadial': 1.8e-6,
+            'wA': 0.0,
+            'wThrust': 0,
+            'wRadial': 0,
+            'QLeak': -8.303463132934355e-08
+        }
+
+        z = pump.output(x)
+        z_test = {
+            'Qout': 0.0174,
+            'To': 290,
+            'Tr': 290.1066,
+            'Tt': 290.0273,
+            'w': 372.6897
+        }
+
+        pump.parameters['x0']['wA'] = 1e-2
+        pump.parameters['x0']['wThrust'] = 1e-10
+        named_results = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
+        times = named_results.times
+        inputs = named_results.inputs
+        states = named_results.states
+        outputs = named_results.outputs
+        event_states = named_results.event_states
 
 # This allows the module to be executed directly
 def run_tests():

--- a/tests/test_pneumatic_valve.py
+++ b/tests/test_pneumatic_valve.py
@@ -330,6 +330,115 @@ class TestPneumaticValve(unittest.TestCase):
     def test_pneumatic_valve(self):
         self.assertEqual(PneumaticValve, PneumaticValveWithWear)
 
+    def test_pneumatic_valve_namedtuple_access(self):
+        m = PneumaticValveWithWear(process_noise= 0)
+
+        cycle_time = 20
+        def future_loading(t, x=None):
+            t = t % cycle_time
+            if t < cycle_time/2:
+                return {
+                    'pL': 3.5e5,
+                    'pR': 2.0e5,
+                    # Open Valve
+                    'uTop': False,
+                    'uBot': True
+                }
+            return {
+                'pL': 3.5e5,
+                'pR': 2.0e5,
+                # Close Valve
+                'uTop': True,
+                'uBot': False
+            }
+
+        u0 = future_loading(0)
+        x0 = m.initialize(u0)
+        x0_test = {
+            'x': 0,
+            'v': 0,
+            'Ai': 0,
+            'r': 6000,
+            'k': 48000,
+            'Aeb': 1e-5,
+            'Aet': 1e-5,
+            'condition': 1,
+            'mTop': 0.067876043046,
+            'mBot': 9.445596253581e-4,
+            'pDiff': u0['pL'] - u0['pR'],
+            'wb': 0,
+            'wi': 0,
+            'wk': 0,
+            'wr': 0,
+            'wt': 0
+        }
+
+        for key in m.states:
+            self.assertAlmostEqual(x0[key], x0_test[key], 7)
+        
+        x = m.next_state(x0, future_loading(0), 0.1)
+        x_test = {
+            'Aeb': 1e-5,
+            'Aet': 1e-5,
+            'Ai': 0,
+            'condition': 1,
+            'k': 48000,
+            'mBot': 0.008534524658,
+            'mTop': 0.048044198904,
+            'r': 6000,
+            'v': 0,
+            'x': 0,
+            'pDiff': u0['pL'] - u0['pR'],
+            'wb': 0,
+            'wi': 0,
+            'wk': 0,
+            'wr': 0,
+            'wt': 0
+        }
+        for key in m.states:
+            self.assertAlmostEqual(x[key], x_test[key], 7)
+
+        z = m.output(x)
+        z_test = {
+            "Q": 0,
+            "iB": True, 
+            "iT": False,
+            "pB": 0.91551734,
+            "pT": 3.7319387914459899,
+            "x": 0
+        }
+        for key in m.outputs:
+            self.assertAlmostEqual(z[key], z_test[key], 7)
+
+        m.parameters['x0']['wr'] = 1
+
+        x0 = m.initialize(u0)
+        x0_test = {
+            'x': 0,
+            'v': 0,
+            'Ai': 0,
+            'r': 6000,
+            'k': 48000,
+            'Aeb': 1e-5,
+            'Aet': 1e-5,
+            'mTop': 0.067876043046,
+            'mBot': 9.445596253581e-4,
+            'pDiff': u0['pL'] - u0['pR'],
+            'wb': 0,
+            'wi': 0,
+            'wk': 0,
+            'wr': 1,
+            'wt': 0
+        }
+
+        config = {'dt': 0.01, 'horizon': 800, 'save_freq': 60}
+        named_results = m.simulate_to_threshold(future_loading, m.output(m.initialize(future_loading(0))), **config)# , 'save_freq': 60
+        times = named_results.times
+        inputs = named_results.inputs
+        states = named_results.states
+        outputs = named_results.outputs
+        event_states = named_results.event_states
+
 # This allows the module to be executed directly
 def run_tests():
     unittest.main()

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -241,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At last it's time to simulate. First we're going to simulate forward 200 seconds. To do this we use the function simulate_to() to simulate to the specified time and print the results"
+    "At last it's time to simulate. First we're going to simulate forward 200 seconds. To do this we use the function simulate_to() to simulate to the specified time and print the results."
    ]
   },
   {
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot the results"
+    "We can also plot the results. "
    ]
   },
   {
@@ -273,6 +273,23 @@
    "source": [
     "event_states.plot(ylabel= 'SOC')\n",
     "outputs.plot(ylabel= {'v': \"voltage (V)\", 't': 'temperature (°C)'}, compact= False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, results can be stored in a container variable and be individually accessed via namedtuple syntax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batt_simulation = batt.simulate_to(time_to_simulate_to, future_loading, **sim_config)\n",
+    "print(batt_simulation.times, batt_simulation.inputs, batt_simulation.states, batt_simulation.outputs, batt_simulation.event_states)"
    ]
   },
   {

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of specifying a specific amount of time, we can also simulate until a threshold has been met using the simulate_to_threshold() method"
+    "Instead of specifying a specific amount of time, we can also simulate until a threshold has been met using the simulate_to_threshold() method. Results can be similarly plotted and accessed via namedtuple syntax."
    ]
   },
   {


### PR DESCRIPTION
Implementing change for simulate_to* methods in prog_models/prognostics_model.py to return namedtuples instead of basic tuples. Motivation for change is ease of readability and access to objects in the return from the method's result. 