### PR TITLE
LazySimResult.extend() check for same fcn

### DIFF
--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -503,10 +503,20 @@ class TestSimResult(unittest.TestCase):
 
         arr = [0,1,2,3,4]
         i = 10
-        self.assertEquals(f1(i,arr), f2(i,arr))
+        self.assertEqual(f1(i,arr), f2(i,arr)) # produce same result
 
         # comparing references to same function
-        self.assertNotEquals(f1,f2)
+        self.assertNotEqual(f1,f2)
+        # comparing bytecode of each; determines if same execution path?
+        self.assertNotEqual(f1.__code__.co_code, f2.__code__.co_code)
+        # using inspect to analyze source code match
+        from inspect import getsource
+        self.assertNotEqual(getsource(f1), getsource(f2))
+        # using dis.dis to analyze disassembled instructions
+        
+        # from dis import dis, info
+        # self.assertNotEqual(info(f1), info(f2)) # dis.dis returns none
+
 
 
     

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -513,12 +513,16 @@ class TestSimResult(unittest.TestCase):
         from inspect import getsource
         self.assertNotEqual(getsource(f1), getsource(f2))
         # using dis.dis to analyze disassembled instructions
+        # from dis import dis
+        # self.assertEqual(dis(f1), dis(f2)) # dis.dis returns none; useless for unittesting
         
-        # from dis import dis, info
-        # self.assertNotEqual(info(f1), info(f2)) # dis.dis returns none
-
-
-
+        # convert to bytecode
+        from dis import Bytecode
+        f1_byte, f2_byte = Bytecode(f1), Bytecode(f2)
+        self.assertNotEqual(f1_byte, f2_byte)
+        self.assertNotEqual(f1_byte.dis(), f2_byte.dis())
+        self.assertNotEqual(f1_byte.info, f2_byte.info)
+        self.assertNotEqual(f1_byte.codeobj, f2_byte.codeobj)
     
 # This allows the module to be executed directly
 def run_tests():

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -488,6 +488,10 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(converted_result.times, [0, 1, 2, 3, 4]) # Compare to expected values
         self.assertEqual(converted_result.data, [0.0, 5.0, 10.0, 15.0, 20.0])
         
+    def test_lazy_extend_fcn_check(self):
+        pass
+
+    
 # This allows the module to be executed directly
 def run_tests():
     unittest.main()

--- a/tests/test_sim_result.py
+++ b/tests/test_sim_result.py
@@ -489,7 +489,25 @@ class TestSimResult(unittest.TestCase):
         self.assertEqual(converted_result.data, [0.0, 5.0, 10.0, 15.0, 20.0])
         
     def test_lazy_extend_fcn_check(self):
-        pass
+        def f1(i, arr):
+            for i in range(len(arr)):
+                arr[i] += i
+            return arr
+
+        def f2(i, arr):
+            index = 0
+            while index < len(arr):
+                arr[index] += i
+                index += 1
+            return arr
+
+        arr = [0,1,2,3,4]
+        i = 10
+        self.assertEquals(f1(i,arr), f2(i,arr))
+
+        # comparing references to same function
+        self.assertNotEquals(f1,f2)
+
 
     
 # This allows the module to be executed directly


### PR DESCRIPTION
Checking experimentation to ensure fcn of both original LazySimResult and other LazySimResult have the same fcn before extending can be performed.