### PR TITLE
Adding comment to LazySimResult describing fcn MUST be the same

### DIFF
--- a/src/prog_models/sim_result.py
+++ b/src/prog_models/sim_result.py
@@ -163,6 +163,7 @@ class LazySimResult(SimResult):  # lgtm [py/missing-equals]
         """
         Extend the LazySimResult with another LazySimResult object
         Raise ValueError if SimResult is passed
+        Function fcn of other LazySimResult MUST match function fcn of LazySimResult object to be extended
 
         Args:
             other (LazySimResult)


### PR DESCRIPTION
Comment informing user that the fcn of both LazySimResult objects must be the same if they are to extend the other