### PR TITLE
Fixed behavior for vectorized models

### DIFF
--- a/src/prog_models/utils/containers.py
+++ b/src/prog_models/utils/containers.py
@@ -29,7 +29,7 @@ class DictLikeMatrixWrapper():
             raise ProgModelTypeError(f"Input must be a dictionary or numpy array, not {type(data)}")     
 
     def __getitem__(self, key):
-        return self.matrix[self._keys.index(key)][0].item()
+        return self.matrix[self._keys.index(key)][0]
 
     def __setitem__(self, key, value):
         self.matrix[self._keys.index(key)] = np.atleast_1d(value)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pkgutil
 from importlib import import_module
 
-examples_skipped = ['dataset', 'vectorized']
+examples_skipped = ['dataset']
 
 def make_test_function(example):
     def test(self):


### PR DESCRIPTION
vectorized models were not working in the current implementation. This is because .item() which converts from np.float64 -> float doesn't work when the element is an ndarray. 

Solution: Dont convert. Users have to use np.float64.


Also, refactored prog_models initializer to use __set_state__, because when copying a prog_model it wasn't running the noise logic. Happily this removed duplicated lines of code!

Fixed the progmodel parameters class from only running the noise logic when changing the noise parameter, but not the noise dict parameter