### PR TITLE
Propagate Matrix work to linear model

### DIFF
--- a/examples/linear_model.py
+++ b/examples/linear_model.py
@@ -75,10 +75,10 @@ class ThrownObject(LinearModel):
     }
 
     def initialize(self, u=None, z=None):
-        return {
+        return self.StateContainer({
             'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
             'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher
-            }
+            })
     
     # This is actually optional. Leaving thresholds_met empty will use the event state to define thresholds.
     #  Threshold = Event State == 0. However, this implementation is more efficient, so we included it
@@ -97,7 +97,8 @@ class ThrownObject(LinearModel):
 
 def run_example():
     m = ThrownObject()
-    future_loading = lambda t, x=None: {}  # No loading 
+    def future_loading(t, x=None):
+        return m.InputContainer({})  # No loading 
     m.simulate_to_threshold(future_loading, print = True, save_freq=1, threshold_keys='impact', dt=0.1)
 
 # This allows the module to be executed directly 

--- a/src/prog_models/linear_model.py
+++ b/src/prog_models/linear_model.py
@@ -99,20 +99,13 @@ class LinearModel(PrognosticsModel, ABC):
         return np.zeros((self.n_events, 1))
 
     def dx(self, x, u):
-        x_array = np.array([list(x.values())]).T
-        u_array = np.array([list(u.values())]).T
-
-        dx_array = np.matmul(self.A, x_array) + np.matmul(self.B, u_array) + self.E
-        return {key: value[0] for key, value in zip(self.states, dx_array)}
+        dx_array = np.matmul(self.A, x.matrix) + np.matmul(self.B, u.matrix) + self.E
+        return self.StateContainer(dx_array)
         
     def output(self, x):
-        x_array = np.array([list(x.values())]).T
-
-        z_array = np.matmul(self.C, x_array) + self.D
-        return {key: value[0] for key, value in zip(self.outputs, z_array)}
+        z_array = np.matmul(self.C, x.matrix) + self.D
+        return self.OutputContainer(z_array)
 
     def event_state(self, x):
-        x_array = np.array([list(x.values())]).T
-
-        es_array = np.matmul(self.F, x_array) + self.G
+        es_array = np.matmul(self.F, x.matrix) + self.G
         return {key: value[0] for key, value in zip(self.events, es_array)}

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -905,10 +905,10 @@ class TestModels(unittest.TestCase):
             }
 
             def initialize(self, u=None, z=None):
-                return {
+                return self.StateContainer({
                     'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
                     'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher
-                    }
+                    })
             
             def threshold_met(self, x):
                 return {
@@ -924,7 +924,7 @@ class TestModels(unittest.TestCase):
                 }
 
         m = ThrownObject()
-        m.simulate_to_threshold(lambda t, x = None: {})
+        m.simulate_to_threshold(lambda t, x = None: m.InputContainer({}))
         # len() = events states inputs outputs
         #         1      2      0      1
 
@@ -1174,10 +1174,10 @@ class TestModels(unittest.TestCase):
             }
 
             def initialize(self, u=None, z=None):
-                return {
+                return self.StateContainer({
                     'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
                     'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher
-                    }
+                    })
             
             def threshold_met(self, x):
                 return {
@@ -1193,7 +1193,7 @@ class TestModels(unittest.TestCase):
                 }
 
         m = ThrownObject()
-        m.simulate_to_threshold(lambda t, x = None: {})
+        m.simulate_to_threshold(lambda t, x = None: m.InputContainer({}))
         m.matrixCheck()
         self.assertIsInstance(m.F, np.ndarray)
         self.assertTrue(np.array_equal(m.F, np.array([[1, 0]])))
@@ -1217,10 +1217,10 @@ class TestModels(unittest.TestCase):
             }
 
             def initialize(self, u=None, z=None):
-                return {
+                return self.StateContainer({
                     'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
                     'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher
-                    }
+                    })
             
             def threshold_met(self, x):
                 return {
@@ -1263,10 +1263,10 @@ class TestModels(unittest.TestCase):
             }
 
             def initialize(self, u=None, z=None):
-                return {
+                return self.StateContainer({
                     'x': self.parameters['thrower_height'],  # Thrown, so initial altitude is height of thrower
                     'v': self.parameters['throwing_speed']  # Velocity at which the ball is thrown - this guy is a professional baseball pitcher
-                    }
+                    })
             
             def threshold_met(self, x):
                 return {


### PR DESCRIPTION
Implement the matrix feature in linear model. This removes the need for conversion, speeding up simulation. 

Also required changes in the example and tests.