### PR TITLE
Update load calculation at midpoint

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -852,8 +852,10 @@ class PrognosticsModel(ABC):
        
         while t < horizon:
             dt = next_time(t, x)
-            t = t + dt
+            t = t + dt/2
+            # Use state at midpoint of step to best represent the load during the duration of the step
             u = future_loading_eqn(t, x)
+            t = t + dt/2
             x = next_state(x, u, dt)
 
             # Save if at appropriate time

--- a/tests/test_centrifugal_pump.py
+++ b/tests/test_centrifugal_pump.py
@@ -3,6 +3,7 @@
 import unittest
 from prog_models.models.centrifugal_pump import CentrifugalPump, CentrifugalPumpWithWear, CentrifugalPumpBase
 
+
 class TestCentrifugalPump(unittest.TestCase):
     def test_centrifugal_pump_base(self):
         pump = CentrifugalPumpBase(process_noise= 0)
@@ -73,7 +74,7 @@ class TestCentrifugalPump(unittest.TestCase):
         pump.parameters['wA'] = 1e-2
         pump.parameters['wThrust'] = 1e-10
         (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
-        self.assertAlmostEqual(times[-1], 23891)
+        self.assertAlmostEqual(times[-1], 23892)
 
     def test_centrifugal_pump_with_wear(self):
         pump = CentrifugalPumpWithWear(process_noise= 0)
@@ -148,7 +149,7 @@ class TestCentrifugalPump(unittest.TestCase):
         pump.parameters['x0']['wA'] = 1e-2
         pump.parameters['x0']['wThrust'] = 1e-10
         (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0),{})))
-        self.assertAlmostEqual(times[-1], 23891)
+        self.assertAlmostEqual(times[-1], 23892)
 
         # Check warning when changing overwritten Parameters
         with self.assertWarns(UserWarning):


### PR DESCRIPTION
This PR is to respond to something @kjjarvis brought up related to the estimation of input from an input function in simulation.

Simulation works by incrementing the state forward with time. Some current state (x_t), a time interval, and an estimation of the input (i.e., loading) during the interval are used to estimate the next state (x_t+1). The current approach is to get the input at the next state and use that as the load for the interval. The problem is that input can be continuous, so this approach is not always an accurate representation of the load during the interval.

![image](https://user-images.githubusercontent.com/8226781/159590097-086bc17f-0872-45a2-9b16-2a5172cafb5e.png)

Our suggested solution is to use the load at the midpoint between time t and t+1 to represent the load for the interval. This would be a better representation in most cases. 
![image](https://user-images.githubusercontent.com/8226781/159590306-6bfd724e-5694-45be-ae62-ea2a381c5ead.png)