### PR TITLE
fix battery circuit dependency

### DIFF
--- a/src/prog_models/models/battery_circuit.py
+++ b/src/prog_models/models/battery_circuit.py
@@ -152,10 +152,15 @@ class BatteryCircuit(PrognosticsModel):
     
     def event_state(self, x : dict) -> dict:
         parameters = self.parameters
-        z = self.output(x)
+        Vcs = x['qcs']/parameters['Cs']
+        Vcp = x['qcp']/parameters['Ccp']
+        SOC = (parameters['CMax'] - parameters['qMax'] + x['qb'])/parameters['CMax']
+        Cb = parameters['Cbp0']*SOC**3 + parameters['Cbp1']*SOC**2 + parameters['Cbp2']*SOC + parameters['Cbp3']
+        Vb = x['qb']/Cb
+        v = Vb - Vcp - Vcs
         charge_EOD = (parameters['CMax'] -
                       parameters['qMax'] + x['qb'])/parameters['CMax']
-        voltage_EOD = (z['v'] - self.parameters['VEOD']) / \
+        voltage_EOD = (v - self.parameters['VEOD']) / \
             self.parameters['VDropoff']
         return {
             'EOD': np.minimum(charge_EOD, voltage_EOD)

--- a/src/prog_models/models/battery_electrochem.py
+++ b/src/prog_models/models/battery_electrochem.py
@@ -321,9 +321,54 @@ class BatteryElectroChemEOD(PrognosticsModel):
         # However, as voltage approaches VEOD, the charge-based approach no 
         # longer accurately captures this behavior, so voltage_EOD takes over as 
         # the driving factor. 
-        z = self.output(x)
+        params = self.parameters
+        An = params['An']
+        # Negative Surface
+        xnS = x['qnS']/params['qSMax']
+        xnS2 = xnS+xnS  # Note: in python x+x is more efficient than 2*x
+        one_minus_xnS = 1 - xnS
+        xnS2_minus_1 = xnS2 - 1
+        VenParts = [
+            An[0] *xnS2_minus_1/F,  # Ven0
+            An[1] *(xnS2_minus_1**2  - (xnS2*one_minus_xnS))/F,  # Ven1
+            An[2] *(xnS2_minus_1**3  - (4 *xnS*one_minus_xnS)*xnS2_minus_1)/F,  #Ven2
+            An[3] *(xnS2_minus_1**4  - (6 *xnS*one_minus_xnS)*xnS2_minus_1**2) /F,  #Ven3
+            An[4] *(xnS2_minus_1**5  - (8 *xnS*one_minus_xnS)*xnS2_minus_1**3) /F,  #Ven4
+            An[5] *(xnS2_minus_1**6  - (10*xnS*one_minus_xnS)*xnS2_minus_1**4) /F,  #Ven5
+            An[6] *(xnS2_minus_1**7  - (12*xnS*one_minus_xnS)*xnS2_minus_1**5) /F,  #Ven6
+            An[7] *(xnS2_minus_1**8  - (14*xnS*one_minus_xnS)*xnS2_minus_1**6) /F,  #Ven7
+            An[8] *(xnS2_minus_1**9  - (16*xnS*one_minus_xnS)*xnS2_minus_1**7) /F,  #Ven8
+            An[9] *(xnS2_minus_1**10 - (18*xnS*one_minus_xnS)*xnS2_minus_1**8) /F,  #Ven9
+            An[10]*(xnS2_minus_1**11 - (20*xnS*one_minus_xnS)*xnS2_minus_1**9) /F,  #Ven10
+            An[11]*(xnS2_minus_1**12 - (22*xnS*one_minus_xnS)*xnS2_minus_1**10)/F,  #Ven11
+            An[12]*(xnS2_minus_1**13 - (24*xnS*one_minus_xnS)*xnS2_minus_1**11)/F   #Ven12
+        ]
+        Ven = params['U0n'] + R*x['tb']/F*np.log(one_minus_xnS/xnS) + sum(VenParts)
+
+        # Positive Surface
+        Ap = params['Ap']
+        xpS = x['qpS']/params['qSMax']
+        xpS2 = xpS + xpS
+        VepParts = [
+            Ap[0] *(xpS2-1)/F,  #Vep0
+            Ap[1] *((xpS2-1)**2  - (xpS2*(1-xpS)))/F,  #Vep1 
+            Ap[2] *((xpS2-1)**3  - (4 *xpS*(1-xpS))/(xpS2-1)**(-1)) /F,  #Vep2
+            Ap[3] *((xpS2-1)**4  - (6 *xpS*(1-xpS))/(xpS2-1)**(-2)) /F,  #Vep3
+            Ap[4] *((xpS2-1)**5  - (8 *xpS*(1-xpS))/(xpS2-1)**(-3)) /F,  #Vep4
+            Ap[5] *((xpS2-1)**6  - (10*xpS*(1-xpS))/(xpS2-1)**(-4)) /F,  #Vep5
+            Ap[6] *((xpS2-1)**7  - (12*xpS*(1-xpS))/(xpS2-1)**(-5)) /F,  #Vep6
+            Ap[7] *((xpS2-1)**8  - (14*xpS*(1-xpS))/(xpS2-1)**(-6)) /F,  #Vep7
+            Ap[8] *((xpS2-1)**9  - (16*xpS*(1-xpS))/(xpS2-1)**(-7)) /F,  #Vep8
+            Ap[9] *((xpS2-1)**10 - (18*xpS*(1-xpS))/(xpS2-1)**(-8)) /F,  #Vep9
+            Ap[10]*((xpS2-1)**11 - (20*xpS*(1-xpS))/(xpS2-1)**(-9)) /F,  #Vep10
+            Ap[11]*((xpS2-1)**12 - (22*xpS*(1-xpS))/(xpS2-1)**(-10))/F,  #Vep11
+            Ap[12]*((xpS2-1)**13 - (24*xpS*(1-xpS))/(xpS2-1)**(-11))/F   #Vep12
+        ]
+        Vep = params['U0p'] + R*x['tb']/F*np.log((1-xpS)/xpS) + sum(VepParts)
+        v = Vep - Ven - x['Vo'] - x['Vsn'] - x['Vsp']
+
         charge_EOD = (x['qnS'] + x['qnB'])/self.parameters['qnMax']
-        voltage_EOD = (z['v'] - self.parameters['VEOD'])/self.parameters['VDropoff'] 
+        voltage_EOD = (v - self.parameters['VEOD'])/self.parameters['VDropoff'] 
         return {
             'EOD': min(charge_EOD, voltage_EOD)
         }


### PR DESCRIPTION
Battery circuit event state called output- this breaks down any ability to subclass the battery circuit with different outputs, because of the outputcontainer filtering feature. 

I break this interdependence by duplicating the code. 