### PR TITLE
Fix bug

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1409,8 +1409,11 @@ class PrognosticsModel(ABC):
                     'save_freq': dmd_dt,
                     'dt': dmd_dt
                 }
+                kwargs_sim = kwargs.copy()
+                kwargs_sim.update(kwargs_temp)
+
                 # Simulate to threshold at DMD time step
-                results = super().simulate_to_threshold(future_loading_eqn,first_output, threshold_keys, **kwargs_temp)
+                results = super().simulate_to_threshold(future_loading_eqn,first_output, threshold_keys, **kwargs_sim)
                 
                 # Interpolate results to be at user-desired time step
                 # Default parameters 


### PR DESCRIPTION
Surrogate sim_to_threshold didn't actually pass any configuration parameters to simulate_to_threshold. So users couldn't set print, progress, horizon, etc. 

This change will allow users to set that, but still enforce the dt and save_points when calling super().simulate_to_threshold()