### PR TITLE
Automatic step size

### DIFF
--- a/examples/sim.py
+++ b/examples/sim.py
@@ -48,7 +48,7 @@ def run_example():
     options['save_freq'] = 201  # Save every 201 seconds
     options['save_pts'] = [250, 772, 1023]  # Special points we sould like to see reported
     simulated_results = batt.simulate_to_threshold(future_loading, **options)
-    # Note that event though the step size is 2, the odd points in the save frequency are met perfectly, dt is adjusted automatically to capture the save points
+    # Note that even though the step size is 2, the odd points in the save frequency are met perfectly, dt is adjusted automatically to capture the save points
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/examples/sim.py
+++ b/examples/sim.py
@@ -43,6 +43,13 @@ def run_example():
     }
     simulated_results = batt.simulate_to_threshold(future_loading, **options)
 
+    # Alternately, you can set a max step size and allow step size to be adjusted automatically
+    options['dt'] = ('auto', 2)  # set step size automatically, with a max of 2 seconds
+    options['save_freq'] = 201  # Save every 201 seconds
+    options['save_pts'] = [250, 772, 1023]  # Special points we sould like to see reported
+    simulated_results = batt.simulate_to_threshold(future_loading, **options)
+    # Note that event though the step size is 2, the odd points in the save frequency are met perfectly, dt is adjusted automatically to capture the save points
+
 # This allows the module to be executed directly 
 if __name__ == '__main__':
     run_example()

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -657,8 +657,11 @@ class PrognosticsModel(ABC):
         -----------------
         t0 : Number, optional
             Starting time for simulation in seconds (default: 0.0) \n
-        dt : Number or function, optional
-            time step (s), e.g. dt = 0.1 or function (t, x) -> dt\n
+        dt : Number, tuple, string, or function, optional
+            Number: constant time step (s), e.g. dt = 0.1\n
+            function (t, x) -> dt\n
+            Tuple: (mode, dt), where modes could be constant or auto. If auto, dt is maximum step size\n
+            string: mode - 'auto' or 'constant'\n
         save_freq : Number, optional
             Frequency at which output is saved (s), e.g., save_freq = 10 \n
         save_pts : List[Number], optional
@@ -839,8 +842,6 @@ class PrognosticsModel(ABC):
                 saved_states.append(deepcopy(x))  # Avoid optimization where x is not copied
 
         # configuring next_time function to define prediction time step, default is constant dt
-    
-
         if callable(config['dt']):
             next_time = config['dt']
             dt_mode = 'function'

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -792,6 +792,34 @@ class TestModels(unittest.TestCase):
         except ProgModelInputException:
             pass
 
+    def test_sim_modes(self):
+        m = ThrownObject(process_noise = 0, measurement_noise = 0)
+        def load(t, x=None):
+            return m.InputContainer({})
+
+        # Default mode should be auto
+        result = m.simulate_to_threshold(load, save_freq = 0.75, save_pts = [1.5, 2.5])
+        self.assertListEqual(result.times, [0, 0.75, 1.5, 1.5, 2.25, 2.5, 3, 3.75])  
+
+        # Auto step size
+        result = m.simulate_to_threshold(load, dt = 'auto', save_freq = 0.75, save_pts = [1.5, 2.5])
+        self.assertListEqual(result.times, [0, 0.75, 1.5, 1.5, 2.25, 2.5, 3, 3.75])  
+
+        # Auto step size with a max of 2
+        result = m.simulate_to_threshold(load, dt = ('auto', 2), save_freq = 0.75, save_pts = [1.5, 2.5])
+        self.assertListEqual(result.times, [0, 0.75, 1.5, 1.5, 2.25, 2.5, 3, 3.75])  
+
+        # Constant step size of 2
+        result = m.simulate_to_threshold(load, dt = ('constant', 2), save_freq = 0.75, save_pts = [1.5, 2.5])
+        self.assertListEqual(result.times, [0, 2, 4])  
+
+        # Constant step size of 2
+        result = m.simulate_to_threshold(load, dt = 2, save_freq = 0.75, save_pts = [1.5, 2.5])
+        self.assertListEqual(result.times, [0, 2, 4])  
+
+        result = m.simulate_to_threshold(load, dt = 2, save_pts = [2.5])
+        self.assertListEqual(result.times, [0, 4])  
+
     # when range specified when state doesnt exist or entered incorrectly
     def test_state_limits(self):
         m = MockProgModel()

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -811,11 +811,11 @@ class TestModels(unittest.TestCase):
 
         # Constant step size of 2
         result = m.simulate_to_threshold(load, dt = ('constant', 2), save_freq = 0.75, save_pts = [1.5, 2.5])
-        self.assertListEqual(result.times, [0, 2, 4])  
+        self.assertListEqual(result.times, [0, 2, 2, 4, 4])  
 
         # Constant step size of 2
         result = m.simulate_to_threshold(load, dt = 2, save_freq = 0.75, save_pts = [1.5, 2.5])
-        self.assertListEqual(result.times, [0, 2, 4])  
+        self.assertListEqual(result.times, [0, 2, 2, 4, 4])  
 
         result = m.simulate_to_threshold(load, dt = 2, save_pts = [2.5])
         self.assertListEqual(result.times, [0, 4])  


### PR DESCRIPTION
Add feature where step size can be determined automatically to capture save_pts and save_freq. This will later support using the step size in the future load as the sim step size. 

Now when setting dt you have the following options:
* Number - constant dt step size
* Function (t, x) -> dt - step size by function
* string - step size mode ('auto' or 'constant').
   * constant is equivalent to dt=1.0
   * auto will set the dt to capture any save pts and save_freq perfectly, and later the future_loading
* tuple (mode, dt)
   * ('constant', dt) - is equivalent to dt=dt
   * ('auto', dt) - sets step size automatically with an upper limit of dt. 

Set default as auto with maximum step size of 1.0. 