### PR TITLE
Exception when dataset has moved

### DIFF
--- a/src/prog_models/datasets/nasa_battery.py
+++ b/src/prog_models/datasets/nasa_battery.py
@@ -87,7 +87,7 @@ def load_data(batt_id : str) -> tuple:
             cache[url] = zipfile.ZipFile(io.BytesIO(response.content))
         except zipfile.BadZipFile:
             # In this case the url may have been forwarded to another page
-            raise ConnectionRefusedError("Data unzip failed- the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
+            raise ConnectionRefusedError("Data unzip failed- The site may be down or the datasets may have moved. Please try again later and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
     f = cache[url].open(f'{cache[url].infolist()[0].filename}Matlab/{batt_id}.mat')
 

--- a/src/prog_models/datasets/nasa_battery.py
+++ b/src/prog_models/datasets/nasa_battery.py
@@ -83,7 +83,11 @@ def load_data(batt_id : str) -> tuple:
             raise ConnectionRefusedError("Data download failed. This may be because of issues with your internet connection or the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
         # Unzip response
-        cache[url] = zipfile.ZipFile(io.BytesIO(response.content))
+        try:
+            cache[url] = zipfile.ZipFile(io.BytesIO(response.content))
+        except zipfile.BadZipFile:
+            # In this case the url may have been forwarded to another page
+            raise ConnectionRefusedError("Data unzip failed- the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
     f = cache[url].open(f'{cache[url].infolist()[0].filename}Matlab/{batt_id}.mat')
 

--- a/src/prog_models/datasets/nasa_cmapss.py
+++ b/src/prog_models/datasets/nasa_cmapss.py
@@ -94,7 +94,7 @@ def load_data(dataset_id : int) -> tuple:
             cache = zipfile.ZipFile(io.BytesIO(response.content))
         except zipfile.BadZipFile:
             # In this case the url may have been forwarded to another page
-            raise ConnectionRefusedError("Data unzip failed- the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
+            raise ConnectionRefusedError("Data unzip failed- The site may be down or the datasets may have moved. Please try again later and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
     # Read Files
     with cache.open(f'test_{dataset_id}.txt', mode='r') as f:

--- a/src/prog_models/datasets/nasa_cmapss.py
+++ b/src/prog_models/datasets/nasa_cmapss.py
@@ -90,7 +90,11 @@ def load_data(dataset_id : int) -> tuple:
             raise ConnectionError("Data download failed. This may be because of issues with your internet connection or the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
         # Unzip response
-        cache = zipfile.ZipFile(io.BytesIO(response.content))
+        try:
+            cache = zipfile.ZipFile(io.BytesIO(response.content))
+        except zipfile.BadZipFile:
+            # In this case the url may have been forwarded to another page
+            raise ConnectionRefusedError("Data unzip failed- the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
     # Read Files
     with cache.open(f'test_{dataset_id}.txt', mode='r') as f:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -24,7 +24,7 @@ class TestDatasets(unittest.TestCase):
         # Legit website, but it's not the repos
         nasa_cmapss.URL = "https://github.com/nasa/prog_models"
         with self.assertRaises(ConnectionError):
-            (desc, data) = nasa_cmapss.load_data(1)
+            (train, test, results) = nasa_cmapss.load_data(1)
     # Testing for successful download located in manual testing files; test_manual.py
 
 # This allows the module to be executed directly

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,16 +7,24 @@ class TestDatasets(unittest.TestCase):
     # Bad URL tests
     def test_nasa_battery_bad_url_download(self):
         from prog_models.datasets import nasa_battery
-        BAD_URL = "BADURLTEST"
-        nasa_battery.urls = {'RW1':"https://"+BAD_URL}
+        nasa_battery.urls = {'RW1':"https://BADURLTEST"}
         with self.assertRaises(ConnectionError):
             (desc, data) = nasa_battery.load_data(1)
+        # Legit website, but it's not the repos
+        nasa_battery.urls = {'RW1':"https://github.com/nasa/prog_models"}
+        with self.assertRaises(ConnectionError):
+            (desc, data) = nasa_battery.load_data(1)
+
     def test_nasa_cmapss_bad_url_download(self):
         from prog_models.datasets import nasa_cmapss
         BAD_URL = "https://"+"BADURLTEST"
         nasa_cmapss.URL = BAD_URL
         with self.assertRaises(ConnectionError):
             (train, test, results) = nasa_cmapss.load_data(1)
+        # Legit website, but it's not the repos
+        nasa_cmapss.URL = "https://github.com/nasa/prog_models"
+        with self.assertRaises(ConnectionError):
+            (desc, data) = nasa_cmapss.load_data(1)
     # Testing for successful download located in manual testing files; test_manual.py
 
 # This allows the module to be executed directly


### PR DESCRIPTION
The website is currently down, and NASA had it forward to a different site. This wasn't caught by our check and the feature gave a weird error. 

This update will catch the issue and give an accurate error.