### PR TITLE
Fix x.matrix size issue in next_state

### DIFF
--- a/src/prog_models/surrogates/dmd.py
+++ b/src/prog_models/surrogates/dmd.py
@@ -249,7 +249,9 @@ class SurrogateDMDModel(LinearModel):
         return self.StateContainer(x)
 
     def next_state(self, x, u, _):   
-        x.matrix = np.matmul(self.A, x.matrix) + np.matmul(self.B, u.matrix) + self.E
+        x.matrix = np.matmul(self.A, x.matrix) + self.E
+        if self.B.shape[1] != 0:
+            x.matrix =+ np.matmul(self.B, u.matrix)
         
         return x   
 

--- a/src/prog_models/surrogates/dmd.py
+++ b/src/prog_models/surrogates/dmd.py
@@ -259,7 +259,7 @@ class SurrogateDMDModel(LinearModel):
     def next_state(self, x, u, _):   
         x.matrix = np.matmul(self.A, x.matrix) + self.E
         if self.B.shape[1] != 0:
-            x.matrix =+ np.matmul(self.B, u.matrix)
+           x.matrix += np.matmul(self.B, u.matrix)
         
         return x   
 


### PR DESCRIPTION
Surrogate method next_state had matrix dimension issues for the case when there were no inputs