### PR TITLE
Add DataModel.from_model

### DIFF
--- a/examples/custom_model.py
+++ b/examples/custom_model.py
@@ -26,6 +26,8 @@ def run_example():
     # Generate data with different loading and step sizes
     # Adding the step size as an element of the output
     training_data = []
+    input_data = []
+    output_data = []
     for i in range(9):
         dt = i/3+0.25
         for loading_eqn in future_loading_eqns:
@@ -33,16 +35,19 @@ def run_example():
             u = np.array([np.hstack((u_i.matrix[:][0].T, [dt])) for u_i in d.inputs], dtype=float)
             z = d.outputs
             training_data.append((u, z))
+            input_data.append(u)
+            output_data.append(z)
 
     # Step 2: Build standard model
     print("Building standard model...")
     m_batt = LSTMStateTransitionModel.from_data(
-        training_data,  
+        inputs = input_data,
+        outputs = output_data,  
         window=12, 
         epochs=30, 
         units=64,  # Additional units given the increased complexity of the system
-        inputs = ['i', 'dt'],
-        outputs = ['t', 'v'])   
+        input_keys = ['i', 'dt'],
+        output_keys = ['t', 'v'])   
 
     # Step 3: Build custom model
     print('Building custom model...')
@@ -84,8 +89,8 @@ def run_example():
     # Step 4: Build LSTMStateTransitionModel
     m_custom = LSTMStateTransitionModel(model, 
         normalization=normalization, 
-        inputs = ['i', 'dt'],
-        outputs = ['t', 'v']
+        input_keys = ['i', 'dt'],
+        output_keys = ['t', 'v']
     )
 
     # Step 5: Simulate

--- a/examples/full_lstm_model.py
+++ b/examples/full_lstm_model.py
@@ -47,13 +47,8 @@ def run_example():
     # unlike the original model. This is necessary to calculate the events.
     # Since the outputs will then match the states, we pass in the states below
 
-    training_data = [
-        (u, data.states),
-        (u_half, data_half.states),
-        (u_quarter, data_quarter.states),
-        (u_twice, data_twice.states),
-        (u_four, data_four.states)
-    ]
+    u_data = [u, u_half, u_quarter, u_twice, u_four]
+    z_data = [data.states, data_half.states, data_quarter.states, data_twice.states, data_four.states]
 
     # Step 3: Create model
     print('Creating model...')
@@ -92,11 +87,12 @@ def run_example():
     # Step 4: Generate Model
     print('Building model...')
     m2 = LSTMThrownObject.from_data(
-        training_data,  
+        inputs=u_data,  
+        outputs=z_data,
         window=4, 
         epochs=30, 
-        inputs = ['dt'],
-        outputs = m.states)
+        input_keys = ['dt'],
+        output_keys = m.states)
 
     # Step 5: Simulate with model
     t_counter = 0

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -111,9 +111,7 @@ def run_example():
     #     [future_loading for _ in range(5)],
     #     dt = [TIMESTEP, TIMESTEP/2, TIMESTEP/4, TIMESTEP*2, TIMESTEP*4],
     #     window=4, 
-    #     epochs=30, 
-    #     input_keys = ['dt'],
-    #     output_keys = ['x'])  
+    #     epochs=30)  
 
     # Step 4: Simulate with model
     t_counter = 0

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -157,16 +157,14 @@ def run_example():
   
     # Step 2: Generate Model
     print('Building model...') 
-    m_batt = LSTMStateTransitionModel.from_model(
-        batt,
-        future_loading_eqns,
+    m_batt = LSTMStateTransitionModel.from_data(
+        inputs = input_data,
+        outputs = output_data,
         window=12, 
         epochs=3, 
         units=64,  # Additional units given the increased complexity of the system
         input_keys = ['i', 'dt'],
-        output_keys = ['t', 'v'],
-        process_noise=0,
-        measurement_noise=0) 
+        output_keys = ['t', 'v']) 
 
     # Step 3: Simulate with model
     t_counter = 0

--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -2,8 +2,11 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from abc import ABC, abstractclassmethod
+from numbers import Number
+import numpy as np
 
 from .. import PrognosticsModel
+from ..exceptions import ProgModelInputException
 
 
 class DataModel(PrognosticsModel, ABC):
@@ -15,7 +18,7 @@ class DataModel(PrognosticsModel, ABC):
     """
 
     @abstractclassmethod
-    def from_data(cls, data: list, **kwargs) -> "DataModel":
+    def from_data(cls, **kwargs) -> "DataModel":
         """
         Create a Data Model from data. This class is overwritten by specific data-driven classes (e.g., LSTM)
 
@@ -23,6 +26,14 @@ class DataModel(PrognosticsModel, ABC):
             data (List[Tuple[Array, Array]]): list of runs to use for training. Each element is a tuple (input, output) for a single run. Input and Output are of size (n_times, n_inputs/outputs)
 
         Keyword Arguments:
+            inputs (List[Array]): list of input data for use in data. Each element is the inputs for a single run of size (n_times, n_inputs)
+            states (List[Array]): list of state data for use in data. Each element is the states for a single run of size (n_times, n_states)
+            outputs (List[Array]): list of output data for use in data. Each element is the outputs for a single run of size (n_times, n_outputs)
+            event_states (List[Array]): list of event state data for use in data. Each element is the event states for a single run of size (n_times, n_event_states)
+            input_keys (list[str]): List of input keys
+            state_keys (list[str]): List of state keys
+            output_keys (list[str]): List of output keys
+            event_keys (list[str]): List of event keys
             See specific data class for more information
 
         Returns:
@@ -34,3 +45,71 @@ class DataModel(PrognosticsModel, ABC):
                 m = DataModel.from_data(data)
         """
         pass
+
+    @classmethod
+    def from_model(cls, m: PrognosticsModel, load_functions: list, **kwargs) -> "DataModel":
+        """
+        Create a Data Model from an existing PrognosticsModel (i.e., a surrogate model). Generates data through simulation with supplied load functions. Then calls from_data to generate the model.
+
+        Args:
+            m (PrognosticsModel): Model to generate data from
+            load_functions (List[Function]): Each index is a callable loading function of (t, x = None) -> z used to predict future loading (output) at a given time (t) and state (x)
+
+        Keyword Args:
+            add_dt (bool): If the timestep should be added as an input
+            Addditional configuration parameters from PrognosticsModel.simulate_to_threshold. These can be an array (of same length as load_functions) of config for each individual sim, or one value to apply to all
+            Additional configuration parameters from from_data
+
+        Returns:
+            DataModel: Trained PrognosticsModel
+        """
+         # Configure
+        config = { # Defaults
+            'add_dt': True
+        }
+        config.update(kwargs)
+
+        if callable(load_functions):
+            # Only one function
+            load_functions = [load_functions]
+
+        sim_cfg_params = ['dt', 't0', 'integration_method', 'save_freq', 'save_pts', 'horizon', 'first_output', 'threshold_keys', 'x', 'thresholds_met_eqn']
+
+        # Check format of cfg item and split into cfg for each sim if scalar
+        for cfg in sim_cfg_params:
+            if cfg in config:
+                if np.isscalar(config[cfg]) or isinstance(config[cfg], tuple) or callable(config[cfg]):
+                    # Single element to be applied to all
+                    config[cfg] = [config[cfg] for _ in load_functions]
+                elif len(config[cfg]) != len(load_functions):
+                    raise ValueError(f"If providing multiple values for sim config item, must provide the same number of values as number of load functions. For {cfg} provided {len(config[cfg])}, expected {len(load_functions)}.")
+                # Otherwise, already in correct form
+
+        if 'dt' not in config:
+            config['dt'] = [1.0 for _ in load_functions]  # default
+        if 'save_freq' not in config:
+            config['save_freq'] = config['dt']
+
+        # Create sim config for each element
+        sim_cfg = [{
+            cfg : config[cfg][i]
+               for cfg in sim_cfg_params if cfg in config
+        } for i in range(len(load_functions))]
+
+        # Simulate
+        data = [m.simulate_to_threshold(load, **sim_cfg[i]) for (i, load) in enumerate(load_functions)]
+
+        # Prepare data
+        if config['add_dt']:
+            if len(data[0].inputs) > 0 and len(data[0].inputs[0]) == 0:
+                # No inputs
+                inputs = [np.array([[config['dt'][i]] for _ in data[i].inputs], dtype=float) for i in range(len(data))]
+            else:
+                inputs = [np.array([np.hstack((u_i.matrix[:][0].T, [config['dt'][i]])) for u_i in d.inputs], dtype=float) for i, d in enumerate(data)]
+        else:
+            inputs = [d.inputs for d in data]
+        outputs = [d.outputs for d in data]
+        states = [d.states for d in data]
+        event_states = [d.event_states for d in data]
+
+        return cls.from_data(inputs = inputs, outputs = outputs, states = states, event_states = event_states, **kwargs)

--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -65,7 +65,11 @@ class DataModel(PrognosticsModel, ABC):
         """
          # Configure
         config = { # Defaults
-            'add_dt': True
+            'add_dt': True,
+            'input_keys': m.inputs.copy(),
+            'output_keys': m.outputs.copy(),
+            'state_keys': m.states.copy(),
+            'event_keys': m.events.copy()
         }
         config.update(kwargs)
 
@@ -96,11 +100,12 @@ class DataModel(PrognosticsModel, ABC):
                for cfg in sim_cfg_params if cfg in config
         } for i in range(len(load_functions))]
 
-        # Simulate
+        # Simulate            
         data = [m.simulate_to_threshold(load, **sim_cfg[i]) for (i, load) in enumerate(load_functions)]
 
         # Prepare data
         if config['add_dt']:
+            config['input_keys'].append('dt')
             if len(data[0].inputs) > 0 and len(data[0].inputs[0]) == 0:
                 # No inputs
                 inputs = [np.array([[config['dt'][i]] for _ in data[i].inputs], dtype=float) for i in range(len(data))]
@@ -112,4 +117,4 @@ class DataModel(PrognosticsModel, ABC):
         states = [d.states for d in data]
         event_states = [d.event_states for d in data]
 
-        return cls.from_data(inputs = inputs, outputs = outputs, states = states, event_states = event_states, **kwargs)
+        return cls.from_data(inputs = inputs, outputs = outputs, states = states, event_states = event_states, **config)

--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -2,11 +2,9 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from abc import ABC, abstractclassmethod
-from numbers import Number
 import numpy as np
 
 from .. import PrognosticsModel
-from ..exceptions import ProgModelInputException
 
 
 class DataModel(PrognosticsModel, ABC):

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -2,6 +2,7 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from collections.abc import Iterable
+from numbers import Number
 import numpy as np
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -260,7 +261,7 @@ class LSTMStateTransitionModel(DataModel):
         for i in range(params['layers']):
             if params['units'][i] <= 0:
                 raise ValueError(f"units[{i}] must be greater than 0, got {params['units'][i]}")
-        if not np.isscalar(params['dropout']):
+        if not isinstance(params['dropout'], Number):
             raise TypeError(f"dropout must be an float greater than or equal to 0, not {type(params['dropout'])}")
         if params['dropout'] < 0:
             raise ValueError(f"dropout must be greater than or equal to 0, got {params['dropout']}")
@@ -268,12 +269,16 @@ class LSTMStateTransitionModel(DataModel):
             params['activation'] = [params['activation'] for _ in range(params['layers'])]
         if not np.isscalar(params['validation_split']):
             raise TypeError(f"validation_split must be an float between 0 and 1, not {type(params['validation_split'])}")
-        if params['validation_split'] < 0 or params['validation_split'] > 1:
+        if params['validation_split'] < 0 or params['validation_split'] >= 1:
             raise ValueError(f"validation_split must be between 0 and 1, got {params['validation_split']}")
         if not np.isscalar(params['epochs']):
             raise TypeError(f"epochs must be an integer greater than 0, not {type(params['epochs'])}")
         if params['epochs'] < 1:
             raise ValueError(f"epochs must be greater than 0, got {params['epochs']}")
+        if np.isscalar(inputs):  # Is scalar (e.g., SimResult)
+            inputs = [inputs]
+        if np.isscalar(outputs):
+            outputs = [outputs]
         if len(inputs) != len(outputs):
             raise ValueError("Inputs must be same length as outputs")
         if not isinstance(inputs, Iterable):

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -93,16 +93,15 @@ class PrognosticsModel(ABC):
     # inputs = []     # Identifiers for each input
     # states = []     # Identifiers for each state
     # outputs = []    # Identifiers for each output
-    performance_metric_keys = []  # Identifies for each performance metric
-    events = []       # Identifiers for each event
+    # performance_metric_keys = []  # Identifies for each performance metric
+    # events = []       # Identifiers for each event
     param_callbacks = {}  # Callbacks for derived parameters
-
-    observables_keys = performance_metric_keys # for backwards compatability        
+      
     SimulationResults = namedtuple('SimulationResults', ['times', 'inputs', 'states', 'outputs', 'event_states'])
 
     def __init__(self, **kwargs):
         if not hasattr(self, 'inputs'):
-            raise ProgModelTypeError('Must have `inputs` attribute')
+            self.inputs = []
         
         if not hasattr(self, 'states'):
             raise ProgModelTypeError('Must have `states` attribute')
@@ -119,6 +118,12 @@ class PrognosticsModel(ABC):
             iter(self.outputs)
         except TypeError:
             raise ProgModelTypeError('model.outputs must be iterable')
+
+        if not hasattr(self, 'performance_metric_keys'):
+            self.performance_metric_keys = []
+
+        if not hasattr(self, 'events'):
+            self.events = []  
         
         # Default params for any model
         params = PrognosticsModel.default_parameters.copy()

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -126,7 +126,9 @@ class PrognosticsModel(ABC):
     def __getstate__(self) -> dict:
         return self.parameters.data
 
-    def __setstate__(self, state : dict) -> None:
+    def __setstate__(self, params : dict) -> None:
+        # This method is called when depickling and in construction. It builds the model from the parameters 
+        
         if not hasattr(self, 'inputs'):
             self.inputs = []
         self.n_inputs = len(self.inputs)
@@ -177,7 +179,7 @@ class PrognosticsModel(ABC):
                 super().__init__(outputs, data)
         self.OutputContainer = OutputContainer
 
-        self.parameters = PrognosticsModelParameters(self, state, self.param_callbacks)
+        self.parameters = PrognosticsModelParameters(self, params, self.param_callbacks)
     
     @abstractmethod
     def initialize(self, u : dict = None, z :dict = None) -> dict:

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -99,32 +99,7 @@ class PrognosticsModel(ABC):
       
     SimulationResults = namedtuple('SimulationResults', ['times', 'inputs', 'states', 'outputs', 'event_states'])
 
-    def __init__(self, **kwargs):
-        if not hasattr(self, 'inputs'):
-            self.inputs = []
-        
-        if not hasattr(self, 'states'):
-            raise ProgModelTypeError('Must have `states` attribute')
-        if len(self.states) <= 0:
-            raise ProgModelTypeError('`states` attribute must have at least one state key')
-        try:
-            iter(self.states)
-        except TypeError:
-            raise ProgModelTypeError('model.states must be iterable')
-
-        if not hasattr(self, 'outputs'):
-            raise ProgModelTypeError('Must have `outputs` attribute')
-        try:
-            iter(self.outputs)
-        except TypeError:
-            raise ProgModelTypeError('model.outputs must be iterable')
-
-        if not hasattr(self, 'performance_metric_keys'):
-            self.performance_metric_keys = []
-
-        if not hasattr(self, 'events'):
-            self.events = []  
-        
+    def __init__(self, **kwargs):                
         # Default params for any model
         params = PrognosticsModel.default_parameters.copy()
 
@@ -152,10 +127,34 @@ class PrognosticsModel(ABC):
         return self.parameters.data
 
     def __setstate__(self, state : dict) -> None:
+        if not hasattr(self, 'inputs'):
+            self.inputs = []
         self.n_inputs = len(self.inputs)
+
+        if not hasattr(self, 'states'):
+            raise ProgModelTypeError('Must have `states` attribute')
+        if len(self.states) <= 0:
+            raise ProgModelTypeError('`states` attribute must have at least one state key')
+        try:
+            iter(self.states)
+        except TypeError:
+            raise ProgModelTypeError('model.states must be iterable')
         self.n_states = len(self.states)
+
+        if not hasattr(self, 'events'):
+            self.events = []  
         self.n_events = len(self.events)
+
+        if not hasattr(self, 'outputs'):
+            raise ProgModelTypeError('Must have `outputs` attribute')
+        try:
+            iter(self.outputs)
+        except TypeError:
+            raise ProgModelTypeError('model.outputs must be iterable')
         self.n_outputs = len(self.outputs)
+
+        if not hasattr(self, 'performance_metric_keys'):
+            self.performance_metric_keys = []
         self.n_performance = len(self.performance_metric_keys)
 
         # Setup Containers 

--- a/src/prog_models/utils/containers.py
+++ b/src/prog_models/utils/containers.py
@@ -25,7 +25,10 @@ class DictLikeMatrixWrapper():
         elif isinstance(data, np.ndarray):
             self.matrix = data
         elif isinstance(data, (dict, DictLikeMatrixWrapper)):
-            self.matrix = np.array([[data[key]] for key in keys], dtype=np.float64)
+            self.matrix = np.array(
+                [
+                    [data[key]] if key in data else [None] for key in keys
+                ], dtype=np.float64)
         else:
             raise ProgModelTypeError(f"Input must be a dictionary or numpy array, not {type(data)}")     
 

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -211,11 +211,8 @@ class TestModels(unittest.TestCase):
         except ProgModelTypeError:
             pass
 
-        try: 
-            m = missing_inputs()
-            self.fail("Should not have worked, missing 'inputs'")
-        except ProgModelTypeError:
-            pass
+        m = missing_inputs()
+        self.assertEmpty(m.inputs)
 
         try: 
             m = missing_outputs()

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -212,7 +212,7 @@ class TestModels(unittest.TestCase):
             pass
 
         m = missing_inputs()
-        self.assertEmpty(m.inputs)
+        self.assertEqual(len(m.inputs), 0)
 
         try: 
             m = missing_outputs()
@@ -253,15 +253,6 @@ class TestModels(unittest.TestCase):
         m = MockProgModel(**{noise_key: add_one})
         x = getattr(m, "apply_{}".format(noise_key))({key: 1 for key in keys})
         self.assertEqual(x[keys[0]], 2)
-
-        try:
-            noise = {}
-            for i in range(len(keys)-1):
-                noise[keys[i]] = i
-            m = MockProgModel(**{noise_key: noise})
-            self.fail("Should have raised exception at missing process_noise key")
-        except KeyError:
-            pass
 
         try:
             noise = []

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -144,9 +144,9 @@ class TestLSTM(unittest.TestCase):
     def test_improper_input(self):
         # Input, output format
         with self.assertRaises(Exception, msg='No outputs'):
-            LSTMStateTransitionModel.from_data(inputs=[])
+            LSTMStateTransitionModel.from_data(inputs=[1])
         with self.assertRaises(Exception, msg='No inputs'):
-            LSTMStateTransitionModel.from_data(outputs=[])
+            LSTMStateTransitionModel.from_data(outputs=[1])
         with self.assertRaises(ValueError, msg='Empty inputs/outputs'):
             LSTMStateTransitionModel.from_data(inputs=[], outputs=[])
         with self.assertRaises(ValueError, msg="Uneven Inputs/outputs"):

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -21,10 +21,11 @@ class TestLSTM(unittest.TestCase):
 
         # Step 2: Generate model
         m2 = LSTMStateTransitionModel.from_data(
-            (data.inputs, data.outputs),  
+            inputs = [data.inputs],
+            outputs = [data.outputs],  
             window=5, 
-            epochs=50,
-            outputs = ['x'])  
+            epochs=25,
+            output_keys = ['x'])  
         self.assertIsInstance(m2, LSTMStateTransitionModel)
         self.assertIsInstance(m2, DataModel)
         self.assertListEqual(m2.outputs, ['x'])
@@ -54,49 +55,149 @@ class TestLSTM(unittest.TestCase):
         self.assertLess(error, 2)
 
         # Create from model
-        m3 = LSTMStateTransitionModel(m2.model, outputs = ['x'])
+        m3 = LSTMStateTransitionModel(m2.model, output_keys = ['x'])
 
         # More tests in examples.lstm_model
 
+    def test_lstm_from_model_thrown_object(self):
+        TIMESTEP = 0.01
+
+        # Step 1: Generate dataed
+        m = ThrownObject()
+
+        def future_loading(t, x=None):
+            return m.InputContainer({})  # No input for thrown object 
+        m3 = LSTMStateTransitionModel.from_model(
+            m,
+            [future_loading for _ in range(5)],
+            dt = [TIMESTEP, TIMESTEP/2, TIMESTEP/4, TIMESTEP*2, TIMESTEP*4],
+            window=2, 
+            epochs=30)  
+
+        # Should get keys from original model
+        self.assertSetEqual(set(m3.inputs), set(['dt', 'x_t-1']))
+        self.assertSetEqual(set(m3.outputs), set(m.outputs))
+
+         # Step 3: Use model to simulate_to time of threshold
+        t_counter = 0
+        x_counter = m.initialize()
+        def future_loading2(t, x = None):
+            # Future Loading is a bit complicated here 
+            # Loading for the resulting model includes the data inputs, 
+            # and the output from the last timestep
+            nonlocal t_counter, x_counter
+            z = m.output(x_counter)
+            z = m3.InputContainer(
+                {
+                    'x_t-1': z['x'],
+                    'dt': TIMESTEP
+                })
+            x_counter = m.next_state(x_counter, future_loading(t), t - t_counter)
+            t_counter = t
+            return z
+        
+        results2 = m3.simulate_to(7.5, future_loading2, dt=TIMESTEP, save_freq=TIMESTEP)
+
+        # Have to do it this way because the other way (i.e., using the LSTM model- the states are not a subset)
+        # Compare RMSE of the results to the original data
+        error = m.calc_error(results2.times, results2.inputs, results2.outputs)
+        self.assertLess(error, 2)
+
+        # Now with no 'dt'
+        #----------------------------------------------------
+        m3 = LSTMStateTransitionModel.from_model(
+            m,
+            [future_loading for _ in range(5)],
+            dt = [TIMESTEP, TIMESTEP/2, TIMESTEP/4, TIMESTEP*2, TIMESTEP*4],
+            window=2, 
+            epochs=30,
+            add_dt = False)  
+
+        # Should get keys from original model
+        self.assertSetEqual(set(m3.inputs), set(['x_t-1']))
+        self.assertSetEqual(set(m3.outputs), set(m.outputs))
+
+         # Step 3: Use model to simulate_to time of threshold
+        t_counter = 0
+        x_counter = m.initialize()
+        def future_loading2(t, x = None):
+            # Future Loading is a bit complicated here 
+            # Loading for the resulting model includes the data inputs, 
+            # and the output from the last timestep
+            nonlocal t_counter, x_counter
+            z = m.output(x_counter)
+            z = m3.InputContainer(
+                {
+                    'x_t-1': z['x']
+                })
+            x_counter = m.next_state(x_counter, future_loading(t), t - t_counter)
+            t_counter = t
+            return z
+        
+        results2 = m3.simulate_to(7.5, future_loading2, dt=TIMESTEP, save_freq=TIMESTEP)
+
+        # Have to do it this way because the other way (i.e., using the LSTM model- the states are not a subset)
+        # Compare RMSE of the results to the original data
+        error = m.calc_error(results2.times, results2.inputs, results2.outputs)
+        self.assertLess(error, 2)
+
     def test_improper_input(self):
-        with self.assertRaises(ValueError, msg='No inputs'):
-            LSTMStateTransitionModel.from_data([])
-        with self.assertRaises(ValueError, msg="Not iterable"):
-            LSTMStateTransitionModel.from_data(12)
-        with self.assertRaises(ValueError, msg="Empty Tuple"):
-            LSTMStateTransitionModel.from_data(())
-        with self.assertRaises(ValueError, msg="Small Tuple"):
-            LSTMStateTransitionModel.from_data((1))
-        with self.assertRaises(ValueError, msg="Too large Tuple"):
-            LSTMStateTransitionModel.from_data((1, 2, 3))
-        with self.assertRaises(ValueError, msg="Too small sequence length"):
-            LSTMStateTransitionModel.from_data((1, 2), window=0)
-        with self.assertRaises(TypeError, msg="Non-scalar sequence length"):
-            LSTMStateTransitionModel.from_data((1, 2), window=[])
-        with self.assertRaises(ValueError, msg="Too few layers"):
-            LSTMStateTransitionModel.from_data((1, 2), layers=0)
-        with self.assertRaises(TypeError, msg="Non-scalar layers"):
-            LSTMStateTransitionModel.from_data((1, 2), layers=[])
-        with self.assertRaises(ValueError, msg="Too few epochs"):
-            LSTMStateTransitionModel.from_data((1, 2), epochs=0)
-        with self.assertRaises(TypeError, msg="Non-scalar epochs"):
-            LSTMStateTransitionModel.from_data((1, 2), epochs=[])
-        with self.assertRaises(IndexError, msg="Uneven Inputs/outputs"):
-            LSTMStateTransitionModel.from_data(([1], [1, 2]))
-        with self.assertRaises(IndexError, msg="Uneven Inputs/outputs-2"):
-            LSTMStateTransitionModel.from_data(([1, 2, 3], [1, 2]))
+        # Input, output format
+        with self.assertRaises(Exception, msg='No outputs'):
+            LSTMStateTransitionModel.from_data(inputs=[])
+        with self.assertRaises(Exception, msg='No inputs'):
+            LSTMStateTransitionModel.from_data(outputs=[])
+        with self.assertRaises(ValueError, msg='Empty inputs/outputs'):
+            LSTMStateTransitionModel.from_data(inputs=[], outputs=[])
+        with self.assertRaises(ValueError, msg="Uneven Inputs/outputs"):
+            LSTMStateTransitionModel.from_data([1], [1, 2])
+        with self.assertRaises(ValueError, msg="Uneven Inputs/outputs-2"):
+            LSTMStateTransitionModel.from_data([1, 2, 3], [1, 2])
         with self.assertRaises(TypeError, msg="Element Format"):
-            LSTMStateTransitionModel.from_data((1, [2]))
+            LSTMStateTransitionModel.from_data(1, [2])
         with self.assertRaises(TypeError, msg="Element Format-2"):
-            LSTMStateTransitionModel.from_data(([1], 2))
+            LSTMStateTransitionModel.from_data([1], 2)
+        with self.assertRaises(TypeError, msg="Not iterable"):
+            LSTMStateTransitionModel.from_data(12, 12)
+
+        # Other Configurables
+        with self.assertRaises(ValueError, msg="Too small sequence length"):
+            LSTMStateTransitionModel.from_data([1], [2], window=0)
+        with self.assertRaises(TypeError, msg="Non-scalar sequence length"):
+            LSTMStateTransitionModel.from_data([1], [2], window=[])
+
+        with self.assertRaises(ValueError, msg="Too few layers"):
+            LSTMStateTransitionModel.from_data([1], [2], layers=0)
+        with self.assertRaises(TypeError, msg="Non-scalar layers"):
+            LSTMStateTransitionModel.from_data([1], [2], layers=[])
+
+        with self.assertRaises(ValueError, msg="Too few epochs"):
+            LSTMStateTransitionModel.from_data([1], [2], epochs=0)
+        with self.assertRaises(TypeError, msg="Non-scalar epochs"):
+            LSTMStateTransitionModel.from_data([1], [2], epochs=[])
+
         with self.assertRaises(TypeError, msg="Normalize type"):
-            LSTMStateTransitionModel.from_data(([1], [2]), normalize=[1, 2])
+            LSTMStateTransitionModel.from_data([1], [2], normalize=[1, 2])
+
+        with self.assertRaises(TypeError, msg="Dropout type"):
+            LSTMStateTransitionModel.from_data([1], [2], dropout = 'abc')   
         with self.assertRaises(ValueError, msg="Negative dropout"):
-            LSTMStateTransitionModel.from_data(([1], [2]), dropout = -1)   
+            LSTMStateTransitionModel.from_data([1], [2], dropout = -1)   
+
         with self.assertRaises(ValueError, msg="Zero units"):
-            LSTMStateTransitionModel.from_data(([1], [2]), units = 0)  
+            LSTMStateTransitionModel.from_data([1], [2], units = 0)  
+
         with self.assertRaises(ValueError, msg="Units, layers mismatch"):
-            LSTMStateTransitionModel.from_data(([1], [2]), units = [1], layers=2)  
+            LSTMStateTransitionModel.from_data([1], [2], units = [1], layers=2)  
+        with self.assertRaises(ValueError, msg="Units, layers mismatch-2"):
+            LSTMStateTransitionModel.from_data([1], [2], units = [1, 2, 3], layers=2)     
+
+        with self.assertRaises(TypeError, msg="Validation Split type"):
+            LSTMStateTransitionModel.from_data([1], [2], validation_split = 'abc')   
+        with self.assertRaises(ValueError, msg="Negative Validation Split"):
+            LSTMStateTransitionModel.from_data([1], [2], validation_split = -1e-5)    
+        with self.assertRaises(ValueError, msg="Validation Split of 1"):
+            LSTMStateTransitionModel.from_data([1], [2], validation_split = 1.0)    
 
 # This allows the module to be executed directly
 def run_tests():


### PR DESCRIPTION
Added from_model class method to DataModel. This will now allow users to create models from others (i.e., surrogates) for any data model class. It essentially generates data from the original model, and then calls the from_data method.

### Made a few changes to the from_data method to support this:
* Split data into inputs, outputs, states, and event_states. This allows model classes to all accept the data they need (e.g., DMD needs all these, but LSTM only needs the first 2). Any additional information received will be ignored
* Renamed the previous inputs, outputs, etc. to input_keys, output_keys, etc. This is to not conflict with the inputs/outputs from the above bullet
* Added a few additional input validation checks into LSTMStateTransitionModel.from_data
* Moved PrognosticsModel.events to be object member instead of class member. This is to prevent a weird behavior where we add to events/inputs/outputs in building the model by appending from the original, and that action editing the default array.  
* Update PrognosticsModel to allow empty input. Not related, just occurred to me as I was doing the above change
* Updated DictLikeMatrixWrapper to allow subset of keys (others are replaced with None). This made building future_loading models for surrogates using the full model easier. 

### A few questions for reviewers (beyond the usual):
* Is the naming inputs, input_keys clear? should we instead do input_data and input_keys?
* Does the interface make sense?

### Follow-on issues for future PRs:
 * #361 