### PR TITLE
Make DataModels Pickle-able

### DIFF
--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -42,6 +42,17 @@ class DataModel(PrognosticsModel, ABC):
         """
         pass
 
+    def __setstate__(self, state):
+        # Set the state (after un-pickling)
+        # If you use the __getstate__ method format below, you dont have to override setstate
+        (args, config) = state
+        self.__init__(*args, **config)
+
+    def __getstate__(self):
+        # This is necessary to support pickling
+        # Override this, replacing the [] with any arguments from the constructor
+        return ([], self.parameters.data)
+
     @classmethod
     def from_model(cls, m: PrognosticsModel, load_functions: list, **kwargs) -> "DataModel":
         """

--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -75,27 +75,34 @@ class DMDModel(LinearModel, DataModel):
             return cls.from_model(dmd_matrix, args[0], **kwargs) 
         return DataModel.__new__(cls)
 
-    def __init__(self, dmd_matrix, *args, **kwargs):
+    def __getstate__(self):
+        return ((self.dmd_matrix,), self.parameters.data)
+
+    def __getnewargs__(self):
+        return (self.dmd_matrix, )
+
+    def __init__(self, dmd_matrix, *_, **kwargs):
         if isinstance(dmd_matrix, PrognosticsModel):
             # Initialized in __new__
             # Remove in future version
             return
 
+        if 'input_keys' not in kwargs:
+            raise ValueError('input_keys must be specified')
+        if 'dt' not in kwargs:
+            raise ValueError('dt must be specified')
+        if 'output_keys' not in kwargs:
+            raise ValueError('output_keys must be specified')
+        if 'x0' not in kwargs:
+            raise ValueError('x0 must be specified')
+
         params = {
+            'state_keys': [],
             'event_keys': []
         }
         params.update(**kwargs)
-        
-        if 'input_keys' not in params:
-            raise ValueError('input_keys must be specified')
-        if 'dt' not in params:
-            raise ValueError('dt must be specified')
-        if 'state_keys' not in params:
-            raise ValueError('state_keys must be specified')
-        if 'output_keys' not in params:
-            raise ValueError('output_keys must be specified')
-        if 'x0' not in params:
-            raise ValueError('x0 must be specified')
+
+        self.dmd_matrix = dmd_matrix
 
         self.inputs = params['input_keys']
         n_inputs = len(params['input_keys'])

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -64,6 +64,9 @@ class LSTMStateTransitionModel(DataModel):
         # Save Model
         self.model = model
 
+    def __getstate__(self):
+        return ((self.model, ), self.parameters.data)
+
     def __eq__(self, other):
         # Needed because we add .model, which is not present in the parent class
         if not isinstance(other, LSTMStateTransitionModel):
@@ -329,7 +332,7 @@ class LSTMStateTransitionModel(DataModel):
         
         # Build model
         callbacks = [
-            keras.callbacks.ModelCheckpoint("jena_sense.keras", save_best_only=True)
+            keras.callbacks.ModelCheckpoint("best_model.keras", save_best_only=True)
         ]
 
         inputs = keras.Input(shape=u_all.shape[1:])
@@ -355,7 +358,7 @@ class LSTMStateTransitionModel(DataModel):
         # Train model
         model.fit(u_all, z_all, epochs=params['epochs'], callbacks = callbacks, validation_split = params['validation_split'])
 
-        return cls(keras.models.load_model("jena_sense.keras"), **params)
+        return cls(keras.models.load_model("best_model.keras"), **params)
         
     def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs):
         t = kwargs.get('t0', 0)

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -66,6 +66,7 @@ class LSTMStateTransitionModel(DataModel):
         self.model = model
 
     def __getstate__(self):
+        warn("LSTMStateTransitionModel uses a Keras model, which does not always support pickling. We recommend that you use the keras save and load model functions instead with m.model", RuntimeWarning)
         return ((self.model, ), self.parameters.data)
 
     def __eq__(self, other):

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -112,7 +112,7 @@ class PrognosticsModel(ABC):
         except TypeError:
             raise ProgModelTypeError("couldn't update parameters. Check that all parameters are valid")
 
-        self.__setstate__(params)
+        PrognosticsModel.__setstate__(self, params)
 
     def __eq__(self, other : "PrognosticsModel") -> bool:
         """

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -71,13 +71,30 @@ class TestDataModel(unittest.TestCase):
         # Create from model
         LSTMStateTransitionModel(m.model, output_keys = ['x'])
 
+        # Test pickling model m
+        import pickle
+        pickled_m = pickle.dumps(m)
+        m2 = pickle.loads(pickled_m)
+        self.assertIsInstance(m2, LSTMStateTransitionModel)
+        self.assertIsInstance(m2, DataModel)
+        self.assertListEqual(m2.outputs, ['x'])
+
         # More tests in examples.lstm_model
 
     def test_dmd_simple(self):
-        self._test_simple_case(DMDModel, max_error=4)
+        self._test_simple_case(DMDModel, max_error=6)
 
         # Without velocity, DMD doesn't perform well
-        self._test_simple_case(DMDModel, WITH_STATES = False, max_error=100)
+        m = self._test_simple_case(DMDModel, WITH_STATES = False, max_error=100)
+
+        # Test pickling model m
+        import pickle
+        pickled_m = pickle.dumps(m)
+        m2 = pickle.loads(pickled_m)
+        self.assertIsInstance(m2, DMDModel)
+        self.assertIsInstance(m2, DataModel)
+        self.assertListEqual(m2.outputs, ['x'])
+
 
     def test_lstm_from_model_thrown_object(self):
         TIMESTEP = 0.01

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -77,7 +77,9 @@ class TestDataModel(unittest.TestCase):
         LSTMStateTransitionModel(m.model, output_keys = ['x'])
 
         # Test pickling model m
-        pickled_m = pickle.dumps(m)
+        with self.assertWarns(RuntimeWarning):
+            # Will raise warning suggesting using save and load from keras.
+            pickled_m = pickle.dumps(m)
         m2 = pickle.loads(pickled_m)
         self.assertIsInstance(m2, LSTMStateTransitionModel)
         self.assertIsInstance(m2, DataModel)


### PR DESCRIPTION
This PR will ensure that DataModels (e.g., LSTM and DMD) can be pickeled and restored. To do so we define the __setstate__ and __getstate__ methods which are called to get the configuration and configure the constructed object. We also define the __getnewargs__ method, which defines the arguments for the __new__ method, when defined. 

To do this, I also had to make DMD matrix an attribute of the DMD class

Also, in DMD.__init__, reordered params building and input checking to make the exception if you give incorrect input a TINY bit faster