### PR TITLE
Fix dmd without dt

### DIFF
--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -201,6 +201,7 @@ class DMDModel(LinearModel, DataModel):
             config['dt'] = sum(config['dt'])/len(config['dt'])
         elif config['dt'] is None:
             # Use times from data - calculate mean dt
+            t = times[0]
             dts = [t[j+1] - t[j]  for j in range(len(t)-1) for t in times]
             config['dt'] = sum(dts)/len(dts)
         if 'save_freq' not in config:

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -17,6 +17,7 @@ class TestDataModel(unittest.TestCase):
         max_error=2, 
         TIMESTEP = 0.01, 
         WITH_STATES = True, 
+        WITH_DT = True,
         **kwargs):
 
         # Step 1: Generate data
@@ -28,6 +29,9 @@ class TestDataModel(unittest.TestCase):
         if WITH_STATES:
             kwargs['states'] = [data.states]
 
+        if WITH_DT:
+            kwargs['dt'] = TIMESTEP
+
         # Step 2: Generate model
         m2 = DataModelType.from_data(
             times = [data.times],
@@ -35,7 +39,6 @@ class TestDataModel(unittest.TestCase):
             outputs = [data.outputs],
             event_states = [data.event_states],  
             output_keys = list(m.outputs),
-            dt = TIMESTEP,
             save_freq = TIMESTEP,
             **kwargs)  
         
@@ -97,6 +100,9 @@ class TestDataModel(unittest.TestCase):
 
     def test_dmd_simple(self):
         self._test_simple_case(DMDModel, max_error=6)
+
+        # Inferring dt
+        self._test_simple_case(DMDModel, max_error=6, WITH_DT = False)
 
         # Without velocity, DMD doesn't perform well
         m = self._test_simple_case(DMDModel, WITH_STATES = False, max_error=100)


### PR DESCRIPTION
DMD was supposed to "infer" dt from the data if not provided. 

This functionality was broken (simple typo). I suspect that block of code was somewhere else in a previous version, then was moved without updating the variable

Also added a test to catch this in the future