### PR TITLE
Fix test copyright

### DIFF
--- a/scripts/test_copyright.py
+++ b/scripts/test_copyright.py
@@ -14,7 +14,7 @@ def check_copyright(directory : str, invalid_files : list) -> bool:
         if os.path.isdir(path):
             result = result and check_copyright(path, invalid_files)
         # If path is a file, ensure it is of type py and check for copyright
-        elif os.path.isfile(path) and path[-2:] == "py":
+        elif path.split(".")[-1] in ("py", "pyw", "py3"):
             file = open(path, 'r')
             copyright_met = False
             # Iterate over lines in file, check each line against COPYRIGHT_TAG

--- a/scripts/test_copyright.py
+++ b/scripts/test_copyright.py
@@ -14,7 +14,7 @@ def check_copyright(directory : str, invalid_files : list) -> bool:
         if os.path.isdir(path):
             result = result and check_copyright(path, invalid_files)
         # If path is a file, ensure it is of type py and check for copyright
-        elif path.split(".")[-1] in ("py", "pyw", "py3"):
+        elif os.path.isfile(path) and path.split(".")[-1] in ("py", "pyw", "py3"):
             file = open(path, 'r')
             copyright_met = False
             # Iterate over lines in file, check each line against COPYRIGHT_TAG


### PR DESCRIPTION
Fix issue where our copyright testing script missed some python files with alternate file extensions (e.g., .pyw or .py3) and checked files that did not require copyright statement (e.g., .npy). 

Issue first identified by user @snoyes in #390