### PR TITLE
Extending LSTM to include event_states, thresh_met

### DIFF
--- a/examples/custom_model.py
+++ b/examples/custom_model.py
@@ -51,7 +51,7 @@ def run_example():
 
     # Step 3: Build custom model
     print('Building custom model...')
-    (u_all, z_all) = LSTMStateTransitionModel.pre_process_data(input_data, output_data, window=12)
+    (u_all, z_all, _, _) = LSTMStateTransitionModel.pre_process_data(input_data, output_data, window=12)
     
     # Normalize
     n_inputs = len(input_data[0][0])

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -158,20 +158,23 @@ def run_example():
     # Adding the step size as an element of the output
     input_data = []
     output_data = []
+    es_data = []
     for i in range(9):
         dt = i/3+0.25
         for loading_eqn in future_loading_eqns:
             d = batt.simulate_to_threshold(loading_eqn, save_freq=dt, dt=dt) 
             input_data.append(np.array([np.hstack((u_i.matrix[:][0].T, [dt])) for u_i in d.inputs], dtype=float))
             output_data.append(d.outputs)
+            es_data.append(d.event_states)
   
     # Step 2: Generate Model
     print('Building model...') 
     m_batt = LSTMStateTransitionModel.from_data(
         inputs = input_data,
         outputs = output_data,
+        event_states = es_data,
         window=12, 
-        epochs=3, 
+        epochs=5, 
         units=64,  # Additional units given the increased complexity of the system
         input_keys = ['i', 'dt'],
         output_keys = ['t', 'v']) 

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -175,7 +175,7 @@ def run_example():
         outputs = output_data,
         event_states = es_data,
         window=12, 
-        epochs=5, 
+        epochs=10, 
         units=64,  # Additional units given the increased complexity of the system
         input_keys = ['i', 'dt'],
         output_keys = ['t', 'v'],

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -160,6 +160,7 @@ def run_example():
     input_data = []
     output_data = []
     es_data = []
+    t_met_data = []
     for i in range(9):
         dt = i/3+0.25
         for loading_eqn in future_loading_eqns:
@@ -167,6 +168,9 @@ def run_example():
             input_data.append(np.array([np.hstack((u_i.matrix[:][0].T, [dt])) for u_i in d.inputs], dtype=float))
             output_data.append(d.outputs)
             es_data.append(d.event_states)
+            t_met = [[False]for _ in d.times]
+            t_met[-1][0] = True  # Threshold has been met at the last timestep
+            t_met_data.append(t_met)
   
     # Step 2: Generate Model
     print('Building model...') 
@@ -174,6 +178,7 @@ def run_example():
         inputs = input_data,
         outputs = output_data,
         event_states = es_data,
+        t_met = t_met_data,
         window=12, 
         epochs=10, 
         units=64,  # Additional units given the increased complexity of the system
@@ -204,7 +209,7 @@ def run_example():
     # Using a dt not used in training will demonstrate the model's 
     # ability to handle different timesteps not part of training set
     data = batt.simulate_to_threshold(future_loading, dt=1, save_freq=1)
-    results = m_batt.simulate_to(data.times[-1], future_loading2, dt=1, save_freq=1)
+    results = m_batt.simulate_to_threshold(future_loading2, dt=1, save_freq=1)
 
     # Step 5: Compare Results
     print('Comparing results...')

--- a/examples/lstm_model.py
+++ b/examples/lstm_model.py
@@ -43,7 +43,7 @@ def run_example():
         inputs = [data.inputs],
         outputs = [data.outputs],  
         window=4, 
-        epochs=30,
+        epochs=30,  # Maximum number of epochs, may stop earlier if early stopping enabled
         output_keys = ['x'])
 
     # We can see the training history
@@ -149,6 +149,7 @@ def run_example():
     # Example 3- More complicated system
     # Here we will create a model for a more complicated system
     # For this example we will use the BatteryElectroChemEOD model
+    # We also include the event state (SOC)
     # -----------------------------------------------------
     print('\n------------------------------------------\nExample 3...')
     print('Generating data...')
@@ -177,7 +178,8 @@ def run_example():
         epochs=5, 
         units=64,  # Additional units given the increased complexity of the system
         input_keys = ['i', 'dt'],
-        output_keys = ['t', 'v']) 
+        output_keys = ['t', 'v'],
+        event_keys=['EOD']) 
 
     # Take a look at the training history.
     m_batt.plot_history()
@@ -208,6 +210,8 @@ def run_example():
     print('Comparing results...')
     data.outputs.plot(title='original model', compact=False)
     results.outputs.plot(title='generated model', compact=False)
+    data.event_states.plot(title='original model', compact=False)
+    results.event_states.plot(title='generated model', compact=False)
     plt.show()
 
     # This last example isn't a perfect fit, but it matches the behavior pretty well

--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -154,6 +154,6 @@ class DataModel(PrognosticsModel, ABC):
         outputs = [d.outputs for d in data]
         states = [d.states for d in data]
         event_states = [d.event_states for d in data]
-        t_met = [m.threshold_met(x) for x in states]
+        t_met = [[list(m.threshold_met(x).values()) for x in state] for state in states]
 
         return cls.from_data(times = times, inputs = inputs, states = states, outputs = outputs, event_states = event_states, t_met= t_met, **config)

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -163,10 +163,6 @@ class LSTMStateTransitionModel(DataModel):
             internal_states = x.matrix[-self.parameters['state_model'].output_shape[1]:].T
         m_event_state = self.parameters['event_state_model'](internal_states)
 
-        if 'normalization' in self.parameters:
-            m_event_state *= self.parameters['normalization'][3]
-            m_event_state += self.parameters['normalization'][2]
-
         return {key: value for key, value in zip(self.events, m_event_state[0])}
 
     def summary(self, file= sys.stdout, expand_nested=False, show_trainable=False):
@@ -439,13 +435,9 @@ class LSTMStateTransitionModel(DataModel):
 
             z_all = (z_all - z_mean)/z_std
 
-            es_mean = np.mean(es_all, axis=0)
-            es_std = np.std(es_all, axis=0)
-            es_all = (es_all - es_mean)/es_std
-
             # u_mean and u_std act on the column vector form (from inputcontainer)
             # so we need to transpose them to a column vector
-            params['normalization'] = (z_mean, z_std, es_mean, es_std)
+            params['normalization'] = (z_mean, z_std)
         
         # Build model
         callbacks = [

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -326,6 +326,8 @@ class LSTMStateTransitionModel(DataModel):
                 list of :term:`input` data for use in data. Each element is the inputs for a single run of size (n_times, n_inputs)
             outputs (list[np.array]): 
                 list of :term:`output` data for use in data. Each element is the outputs for a single run of size (n_times, n_outputs)
+            event_states (list[np.array], optional): 
+                list of :term:`event state` data for use in data. Each element is the event state for a single run of size (n_times, n_events)
 
         Keyword Args:
             window (int): 
@@ -334,6 +336,8 @@ class LSTMStateTransitionModel(DataModel):
                 List of keys to use to identify :term:`input`. If not supplied u[#] will be used to idenfiy inputs
             output_keys (list[str]): 
                 List of keys to use to identify :term:`output`. If not supplied z[#] will be used to idenfiy outputs
+            event_keys (list[str]):
+                List of keys to use to identify events for :term:`event state` and :term:`threshold met`. If not supplied event[#] will be used to idenfiy events
             validation_percentage (float): 
                 Percentage of data to use for validation, between 0-1
             epochs (int): 

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -23,12 +23,15 @@ class LSTMStateTransitionModel(DataModel):
     Most users will use the `LSTMStateTransitionModel.from_data` method to create a model, but the model can be created by passing in a model directly into the constructor. The LSTM model in this method maps from [u_t-n+1, z_t-n, ..., u_t, z_t-1] to z_t. Past :term:`input` are stored in the :term:`model` internal :term:`state`. Actual calculation of :term:`output` is performed when :py:func`LSTMStateTransitionModel.output` is called. When using in simulation that may not be until the simulation results are accessed.
 
     Args:
-        output_model (keras.Model): If a state model is present, mapps from the state_model outputs to model outputs. Otherwise, maps from model inputs to model outputs
-        state_model (keras.Model): Keras model to use for state transition, optional
+        output_model (keras.Model): If a state model is present, maps from the state_model outputs to model :term:`output`. Otherwise, maps from model inputs to model :term:`output`
+        state_model (keras.Model, optional): Keras model to use for state transition
+        event_state_model (keras.Model, optional): If a state model is present, maps from the state_model outputs to :term:`event state`. Otherwise, maps from model inputs to :term:`event state`
+        t_met_model (keras.Model, optional): If a state model is present, maps from the state_model outputs to if the threshold has been met. Otherwise, maps from model inputs to if the threshold has not been met
 
     Keyword Args:
         input_keys (list[str]): List of input keys
         output_keys (list[str]): List of output keys
+        event_keys (list[str]): List of event keys
 
     Attributes:
         model (keras.Model): Keras model to use for state transition

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -156,7 +156,7 @@ class LSTMStateTransitionModel(DataModel):
     def event_state(self, x):
         if self.parameters['event_state_model'] is None:
             warn('No event state model exists- returning empty event state')
-            return {}
+            return {key: None for key in self.events}
         
         if x.matrix[0,0] is None:
             warn(f"Event state estimation is not available until at least {1+self.parameters['window']} timesteps have passed.")
@@ -176,7 +176,7 @@ class LSTMStateTransitionModel(DataModel):
     def threshold_met(self, x):
         if self.parameters['t_met_model'] is None:
             warn('No threshold met model exists- returning empty t_met')
-            return {}
+            return {key: None for key in self.events}
         
         if x.matrix[0,0] is None:
             warn(f"Threshold met estimation is not available until at least {1+self.parameters['window']} timesteps have passed.")
@@ -361,7 +361,7 @@ class LSTMStateTransitionModel(DataModel):
                         n_events = len(t[0])
                         t_i = [[t[i][k] for k in range(n_events)] for i in range(window+1, len(t))]
                     else:
-                        raise TypeError(f"Unsupported input type: {type(t)} for internal element (t[i])")  
+                        raise TypeError(f"Unsupported input type: {type(t[0])} for internal element (t[i])")  
 
                 else:
                     raise TypeError(f"Unsupported data type: {type(t)}. t_met must be in format List[Tuple[np.array, np.array]] or List[Tuple[SimResult, SimResult]]")
@@ -563,7 +563,7 @@ class LSTMStateTransitionModel(DataModel):
             t_met_layer = model.get_layer('t_met')(output_layer_input)
             t_met_model = keras.Model(output_layer_input, t_met_layer)  
 
-        return cls(output_model, state_model, event_state_model, history = history, **params)
+        return cls(output_model, state_model, event_state_model, t_met_model, history = history, **params)
         
     def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs):
         t = kwargs.get('t0', 0)

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -24,14 +24,13 @@ class PrognosticsModelParameters(UserDict):
         dict_in: Initial parameters
         callbacks: Any callbacks for derived parameters f(parameters) : updates (dict)
     """
-    def __init__(self, model : "PrognosticsModel", dict_in : dict = {}, callbacks : dict = {}):
+    def __init__(self, model : "PrognosticsModel", dict_in : dict = {}, callbacks : dict = {}, _copy: bool = True):
         super().__init__()
         self._m = model
         self.callbacks = {}
         # Note: Callbacks are set to empty to prevent calling callbacks with a partial or empty dict on line 32. 
         for (key, value) in dict_in.items():
-            # Deepcopy is needed here to force copying when value is an object (e.g., dict)
-            self[key] = deepcopy(value)
+            self.__setitem__(key, value, _copy=_copy)
 
         # Add and run callbacks
         # Has to be done here so the base parameters are all set 
@@ -42,7 +41,7 @@ class PrognosticsModelParameters(UserDict):
                     changes = callback(self)
                     self.update(changes)
 
-    def __setitem__(self, key : str, value : float) -> None:
+    def __setitem__(self, key : str, value : float, _copy : bool = True) -> None:
         """Set model configuration, overrides dict.__setitem__()
 
         Args:
@@ -52,6 +51,10 @@ class PrognosticsModelParameters(UserDict):
         Raises:
             ProgModelTypeError: Improper configuration for a model
         """
+        # Deepcopy is needed here to force copying when value is an object (e.g., dict)
+        if _copy:
+            value = deepcopy(value)
+        
         super().__setitem__(key, value)
 
         if key in self.callbacks:


### PR DESCRIPTION
Extending the divided LSTM model introduced in #395 to include estimation of threshold_met and event_state. Each of these are optional, only working if the relevant data is provided. 

Event_state is just like outputs, but thresholdmet is calculated using softmax (since it's a classification problem). 

Example for battery was extended to include this. 

[Presentation1.pdf](https://github.com/nasa/prog_models/files/9568311/Presentation1.pdf)
