### PR TITLE
A few LSTM Bugfixes

### DIFF
--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -262,12 +262,12 @@ class LSTMStateTransitionModel(DataModel):
                 elif np.isscalar(u[0]):
                     # Input is 1-d array (i.e., 1 input)
                     # Note: 1 is added to account for current time (current input used to predict output at time i)
-                    u_i = [[[u[i+j]] for j in range(1, window+1)] for i in range(len(u)-window-1)]
+                    u_i = [[[u[i+j]] for j in range(1, window+1)] for i in range(len(u)-window)]
                 elif isinstance(u[0], (list, np.ndarray)):
                     # Input is d-d array
-                    # Note: 1 is added to account for current time (current input used to predict output at time i)
+                    # Note: 1 is added to account for current time (current input used to predict output at time i) 
                     n_inputs = len(u[0])
-                    u_i = [[[u[i+j][k] for k in range(n_inputs)] for j in range(1,window+1)] for i in range(len(u)-window-1)]
+                    u_i = [[[u[i+j][k] for k in range(n_inputs)] for j in range(1,window+1)] for i in range(len(u)-window)]
                 else:
                     raise TypeError(f"Unsupported input type: {type(u)} for internal element (data[0][i]")  
             else:
@@ -293,21 +293,23 @@ class LSTMStateTransitionModel(DataModel):
                     z_i = []
                 elif np.isscalar(z[0]):
                     # Output is 1-d array (i.e., 1 output)
-                    z_i = [[z[i]] for i in range(window+1, len(z))]
+                    z_i = [[z[i]] for i in range(window, len(z))]
                 elif isinstance(z[0], (list, np.ndarray)):
                     # Input is d-d array
                     n_outputs = len(z[0])
-                    z_i = [[z[i][k] for k in range(n_outputs)] for i in range(window+1, len(z))]
+                    z_i = [[z[i][k] for k in range(n_outputs)] for i in range(window, len(z))]
                 else:
                     raise TypeError(f"Unsupported input type: {type(z)} for internal element (output[i])")  
 
                 # Also add to input (past outputs are part of input)
+                z_ii = [[z[i+j] for j in range(window)] for i in range(len(z_i))]
+                # ISSUE- TODO z_ii has too many dimensions
                 if len(u_i) == 0:
-                    u_i = [[z_ii for _ in range(window)] for z_ii in z_i]
+                    u_i = z_ii
                 else:
-                    for k in range(len(z_i)):
+                    for k in range(len(z_ii)):
                         for j in range(window):
-                            u_i[k][j].extend(z_i[k])
+                            u_i[k][j].extend(z_ii[k][j])
             else:
                 raise TypeError(f"Unsupported data type: {type(z)}. output z must be in format List[Tuple[np.array, np.array]] or List[Tuple[SimResult, SimResult]]")
             
@@ -330,11 +332,11 @@ class LSTMStateTransitionModel(DataModel):
                         es_i = []
                     elif np.isscalar(es[0]):
                         # Output is 1-d array (i.e., 1 output)
-                        es_i = [[es[i]] for i in range(window+1, len(es))]
+                        es_i = [[es[i]] for i in range(window, len(es))]
                     elif isinstance(es[0], (list, np.ndarray)):
                         # Input is d-d array
                         n_events = len(es[0])
-                        es_i = [[es[i][k] for k in range(n_events)] for i in range(window+1, len(es))]
+                        es_i = [[es[i][k] for k in range(n_events)] for i in range(window, len(es))]
                     else:
                         raise TypeError(f"Unsupported input type: {type(es)} for internal element (es[i])")  
 
@@ -362,12 +364,12 @@ class LSTMStateTransitionModel(DataModel):
                         t_i = []
                     elif np.isscalar(t[0]):
                         # Output is 1-d array (i.e., 1 output)
-                        t_i = [[1, 0] if t[i] else [0, 1] for i in range(window+1, len(t))]
+                        t_i = [[1, 0] if t[i] else [0, 1] for i in range(window, len(t))]
                     elif isinstance(t[0], (list, np.ndarray)):
                         # Input is d-d array
                         n_events = len(t[0])
                         # True = 1, 0; False = 0, 1
-                        t_i = [list(chain.from_iterable((1, 0) if t[i][k] else (0, 1) for k in range(n_events))) for i in range(window+1, len(t))]
+                        t_i = [list(chain.from_iterable((1, 0) if t[i][k] else (0, 1) for k in range(n_events))) for i in range(window, len(t))]
                     else:
                         raise TypeError(f"Unsupported input type: {type(t[0])} for internal element (t[i])")  
 

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -441,7 +441,7 @@ class LSTMStateTransitionModel(DataModel):
         params = { # default_params
             'window': 128,
             'validation_split': 0.25,
-            'epochs': 2,
+            'epochs': 100,
             'prediction_steps': 1,
             'layers': 1,
             'units': 16,

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -31,19 +31,20 @@ class TestDataModel(unittest.TestCase):
         data = m.simulate_to_threshold(future_loading, threshold_keys='impact', save_freq=TIMESTEP, dt=TIMESTEP)
 
         if WITH_STATES:
-            kwargs['states'] = [data.states]
+            kwargs['states'] = [data.states, data.states]
 
         if WITH_DT:
             kwargs['dt'] = TIMESTEP
 
         # Step 2: Generate model
         m2 = DataModelType.from_data(
-            times = [data.times],
-            inputs = [data.inputs],
-            outputs = [data.outputs],
-            event_states = [data.event_states],  
+            times = [data.times, data.times],
+            inputs = [data.inputs, data.inputs],
+            outputs = [data.outputs, data.outputs],
+            event_states = [data.event_states, data.event_states],  
             output_keys = list(m.outputs),
             save_freq = TIMESTEP,
+            validation_split=0.5,
             **kwargs)  
         
         self.assertIsInstance(m2, DataModelType)


### PR DESCRIPTION
The LSTM model was performing poorly, resulting in poor test performance, like that shown below (right is LSTM, left is original)
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/8226781/194393934-36bdd35b-f45a-4c9f-b1e5-c8c90013bcd8.png)

Investigation of this fault identified a few issues, some with the tests, others with the actual functionality. 
1. LSTM preprocessing wasn't using all the data. It was missing one datapoint for each run
2. LSTM preprocessing wasn't calculating the output window correctly (z_ii) for appending to u.
3. Tests - Training just had one run, and part of it was used for validation, so the training data was incomplete. To fix this I duplicated the data. Not good practice, but it was ok for the test. 

I also increased the default number of epochs. The default was unreasonably low. 