### PR TITLE
Add missing pickle import to custom encoder

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1309,6 +1309,7 @@ class PrognosticsModel(ABC):
                 dict_temp['_original_type'] = 'DictLikeMatrixWrapper'
                 return dict_temp 
             else: 
+                import pickle
                 from base64 import b64encode
                 pkl_temp = b64encode(pickle.dumps(o))
                 save_temp = {}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,4 @@
-# Copyright © 2022 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
+# Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
 import unittest
 import numpy as np


### PR DESCRIPTION
The custom encoder for serializing parameters in prognostics_model was missing a pickle import. Added pickle import. Also changed copyright date in test_serialization.