### PR TITLE
Reconfigure numpy bool in serialization encoder

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1307,7 +1307,13 @@ class PrognosticsModel(ABC):
             elif isinstance(o, DictLikeMatrixWrapper):
                 dict_temp = {k: v for k, v in o.items()}
                 dict_temp['_original_type'] = 'DictLikeMatrixWrapper'
-                return dict_temp 
+                return dict_temp
+            elif isinstance(o,np.bool_):
+                if o == False:
+                    o = False
+                else: 
+                    o = True
+                return o 
             else: 
                 import pickle
                 from base64 import b64encode

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1346,11 +1346,7 @@ class PrognosticsModel(ABC):
                 dict_temp['_original_type'] = 'DictLikeMatrixWrapper'
                 return dict_temp
             elif isinstance(o,np.bool_):
-                if o == False:
-                    o = False
-                else: 
-                    o = True
-                return o 
+                return bool(o) 
             else: 
                 import pickle
                 from base64 import b64encode


### PR DESCRIPTION
When serializing a model, if the custom encoder received a numpy.bool_ value, it pickled the result. We've now added a reconfiguration of these numpy.bool_ values to be standard bool values, which are supported by JSON so no pickling is required. 