### PR TITLE
Various bug fixes to the data model

### DIFF
--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -100,8 +100,15 @@ class DMDModel(LinearModel, DataModel):
         self.outputs = params['output_keys']
         n_outputs = len(params['output_keys'])
         
-        self.events = params['event_keys']
-        n_events = len(params['event_keys'])
+        has_overwritten_threshold_eqn = hasattr(self, 'events')
+        if has_overwritten_threshold_eqn: 
+             # To support overridding to add custom threshold equation
+            n_events = 0
+        else:
+            self.events = params['event_keys']
+            n_events = len(self.events)
+
+
         n_total = n_states + n_outputs + n_events
 
         self.A = dmd_matrix[:,0:n_total]
@@ -109,7 +116,8 @@ class DMDModel(LinearModel, DataModel):
         self.C = np.zeros((n_outputs,n_total))
         for iter1 in range(n_outputs):
             self.C[iter1,n_states+iter1] = 1 
-        self.F = np.zeros((n_events,n_total))
+        if not has_overwritten_threshold_eqn:
+            self.F = np.zeros((n_events,n_total))
         for iter2 in range(n_events):
             self.F[iter2,n_states+n_outputs+iter2] = 1 
 

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -255,6 +255,9 @@ class LSTMStateTransitionModel(DataModel):
                 else:
                     u = np.array([u_i.matrix[:,0] for u_i in u])
 
+                if len(u) > window:
+                    raise TypeError(f"Not enough data for window size {window}. Only {len(u)} elements present.")
+
             if isinstance(u, (list, np.ndarray)):
                 if len(u) == 0:
                     # No inputs
@@ -641,6 +644,8 @@ class LSTMStateTransitionModel(DataModel):
         x.matrix = np.array(x.matrix, dtype=np.float)
         kwargs['x'] = x
         if 'horizon' in kwargs:
+            if kwargs['horizon'] < t:
+                raise ValueError('Prediction horizon does not allow enough steps to fully initialize model')
             kwargs['horizon'] = kwargs['horizon'] - t
         return super().simulate_to_threshold(future_loading_eqn, first_output, threshold_keys, **kwargs)
     

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -599,7 +599,7 @@ class LSTMStateTransitionModel(DataModel):
         
     def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs):
         t = kwargs.get('t0', 0)
-        dt = kwargs.get('dt', 0)
+        dt = kwargs.get('dt', 0.1)
         x = kwargs.get('x', self.initialize(future_loading_eqn(t), first_output))
 
         # configuring next_time function to define prediction time step, default is constant dt

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -768,7 +768,7 @@ class PrognosticsModel(ABC):
         if not isinstance(config['horizon'], Number):
             raise ProgModelInputException("'horizon' must be a number, was a {}".format(type(config['horizon'])))
         if config['horizon'] < 0:
-            raise ProgModelInputException("'save_freq' must be positive, was {}".format(config['horizon']))
+            raise ProgModelInputException("'horizon' must be positive, was {}".format(config['horizon']))
         if 'x' in config and not all([state in config['x'] for state in self.states]):
             raise ProgModelInputException("'x' must contain every state in model.states")
         if 'thresholds_met_eqn' in config and not callable(config['thresholds_met_eqn']):


### PR DESCRIPTION
This PR includes various bug fixes. Specifically:
* Update DMD Model to support overwritten threshold_met equation (used in ASO project). For example, if you have a definition of threshold_met as a function of the outputs, rather than learning that relationship, you can define it by overriding threshold_met
* LSTM Model- added exception if you do not provide enough data to fill the window. E.g., if you provide a time series of length 10 to learn a model with a window of 20. 
* LSTM Model - updated default dt to be positive. Before it was 0- which means it would never move forward
* LSTM model - Added exception in simulate_to_threshold if you're not simulating far enough forward to fill the window. E.g., if you have a window size of 20, but are only simulating 10 steps
* Prognostics Model - fix typo in one of the exceptions