### PR TITLE
Make Event State equation optional

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -549,7 +549,7 @@ class PrognosticsModel(ABC):
         threshold_met
         """
         if type(self).threshold_met == PrognosticsModel.threshold_met:
-            # Threshold Met and Event States are both not overridden
+            # Neither Threshold Met nor Event States are overridden
             return {}
         
         return {key: 1.0-float(t_met) \
@@ -588,7 +588,7 @@ class PrognosticsModel(ABC):
         event_state
         """
         if type(self).event_state == PrognosticsModel.event_state:
-            # Threshold Met and Event States are both not overridden
+            # Neither Threshold Met nor Event States are overridden
             return {}
 
         return {key: event_state <= 0 \

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -548,7 +548,12 @@ class PrognosticsModel(ABC):
         --------
         threshold_met
         """
-        return {}
+        if type(self).threshold_met == PrognosticsModel.threshold_met:
+            # Threshold Met and Event States are both not overridden
+            return {}
+        
+        return {key: 1.0-float(t_met) \
+            for (key, t_met) in self.threshold_met(x).items()} 
     
     def threshold_met(self, x : dict) -> dict:
         """
@@ -582,6 +587,10 @@ class PrognosticsModel(ABC):
         --------
         event_state
         """
+        if type(self).event_state == PrognosticsModel.event_state:
+            # Threshold Met and Event States are both not overridden
+            return {}
+
         return {key: event_state <= 0 \
             for (key, event_state) in self.event_state(x).items()} 
 

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -542,7 +542,7 @@ class PrognosticsModel(ABC):
 
         Note
         ----
-        Default is to return an empty array (for system models that do not include any events)
+        If not overridden, will return 0.0 if threshold_met returns True, otherwise 1.0. If neither threshold_met or event_state is overridden, will return an empty dictionary (i.e., no events)
         
         See Also
         --------
@@ -581,7 +581,7 @@ class PrognosticsModel(ABC):
 
         Note
         ----
-        If not overwritten, the default behavior is to say the threshold is met if the event state is <= 0
+        If not overridden, will return True if event_state is <= 0, otherwise False. If neither threshold_met or event_state is overridden, will return an empty dictionary (i.e., no events)
         
         See Also
         --------

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -352,6 +352,39 @@ class TestModels(unittest.TestCase):
         t = m.threshold_met({'t': 10})
         self.assertTrue(t['e1'])
 
+    def test_default_es_and_tm(self):
+        # Test 1: TM only
+        class NoES(MockModel, prognostics_model.PrognosticsModel):
+            events = ['e1', 'e2']
+
+            def threshold_met(self, _):
+                return {'e1': False, 'e2': True}
+
+        m = NoES()
+
+        self.assertDictEqual(m.threshold_met({}), {'e1': False, 'e2': True})
+        self.assertDictEqual(m.event_state({}), {'e1': 1.0, 'e2': 0.0})
+
+        # Test 2: ES only
+        class NoTM(MockModel, prognostics_model.PrognosticsModel):
+            events = ['e1', 'e2']
+
+            def event_state(self, _):
+                return {'e1': 0.0, 'e2': 1.0}
+        
+        m = NoTM()
+
+        self.assertDictEqual(m.threshold_met({}), {'e1': True, 'e2': False})
+        self.assertDictEqual(m.event_state({}), {'e1': 0.0, 'e2': 1.0})
+
+        # Test 3: Neither ES or TM 
+        class NoESTM(MockModel, prognostics_model.PrognosticsModel):
+            events = []
+
+        m = NoESTM()
+        self.assertDictEqual(m.threshold_met({}), {})
+        self.assertDictEqual(m.event_state({}), {})
+
     def test_model_gen(self):
         keys = {
             'states': ['a', 'b', 'c', 't'],


### PR DESCRIPTION
This PR updates behavior if event state or threshold_met is not provided:

* If event_state is not overridden, but threshold_met is: Will return event_state of 0 if threshold_met is True, else 1
* if threshold_met is overridden, but event_state is not: Will return threshold_met of True if event_state is 0, else False
* if neither are overridden: Will return empty dict (i.e., no events). 