### PR TITLE
Fix issues with datasets

### DIFF
--- a/src/prog_models/datasets/nasa_battery.py
+++ b/src/prog_models/datasets/nasa_battery.py
@@ -46,6 +46,8 @@ def load_data(batt_id : str) -> tuple:
     """
     .. versionadded:: 1.3.0
 
+    BATTERY DATA IS CURRENTLY UNAVAILABLE
+
     Loads data for one or more batteries from NASA's PCoE Dataset, '11. Randomized Battery Usage Data Set'
     https://www.nasa.gov/content/prognostics-center-of-excellence-data-set-repository
 
@@ -67,6 +69,7 @@ def load_data(batt_id : str) -> tuple:
     
         In all other instances of connection error or failed downloading, please submit an issue on the repository page (https://github.com/nasa/prog_models/issues) for our team to look into.
     """
+    raise NotImplementedError("Battery data is currently unavailable. Access will be restored in a future release.")
     if isinstance(batt_id, int):
         # Convert to string
         batt_id = 'RW' + str(batt_id)

--- a/src/prog_models/datasets/nasa_cmapss.py
+++ b/src/prog_models/datasets/nasa_cmapss.py
@@ -7,7 +7,7 @@ import requests
 import zipfile
 
 cache = None
-URL = "https://ti.arc.nasa.gov/c/6/"
+URL = "https://data.nasa.gov/download/ff5v-kuh6/application%2Fzip"
 
 
 def load_data(dataset_id : int) -> tuple:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,15 +5,16 @@ import unittest
 
 class TestDatasets(unittest.TestCase):
     # Bad URL tests
-    # def test_nasa_battery_bad_url_download(self):
-    #     from prog_models.datasets import nasa_battery
-    #     nasa_battery.urls = {'RW1':"https://BADURLTEST"}
-    #     with self.assertRaises(ConnectionError):
-    #         (desc, data) = nasa_battery.load_data(1)
-    #     # Legit website, but it's not the repos
-    #     nasa_battery.urls = {'RW1':"https://github.com/nasa/prog_models"}
-    #     with self.assertRaises(ConnectionError):
-    #         (desc, data) = nasa_battery.load_data(1)
+    @unittest.skip
+    def test_nasa_battery_bad_url_download(self):
+        from prog_models.datasets import nasa_battery
+        nasa_battery.urls = {'RW1':"https://BADURLTEST"}
+        with self.assertRaises(ConnectionError):
+            (desc, data) = nasa_battery.load_data(1)
+        # Legit website, but it's not the repos
+        nasa_battery.urls = {'RW1':"https://github.com/nasa/prog_models"}
+        with self.assertRaises(ConnectionError):
+            (desc, data) = nasa_battery.load_data(1)
 
     def test_nasa_cmapss_bad_url_download(self):
         from prog_models.datasets import nasa_cmapss

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,15 +5,15 @@ import unittest
 
 class TestDatasets(unittest.TestCase):
     # Bad URL tests
-    def test_nasa_battery_bad_url_download(self):
-        from prog_models.datasets import nasa_battery
-        nasa_battery.urls = {'RW1':"https://BADURLTEST"}
-        with self.assertRaises(ConnectionError):
-            (desc, data) = nasa_battery.load_data(1)
-        # Legit website, but it's not the repos
-        nasa_battery.urls = {'RW1':"https://github.com/nasa/prog_models"}
-        with self.assertRaises(ConnectionError):
-            (desc, data) = nasa_battery.load_data(1)
+    # def test_nasa_battery_bad_url_download(self):
+    #     from prog_models.datasets import nasa_battery
+    #     nasa_battery.urls = {'RW1':"https://BADURLTEST"}
+    #     with self.assertRaises(ConnectionError):
+    #         (desc, data) = nasa_battery.load_data(1)
+    #     # Legit website, but it's not the repos
+    #     nasa_battery.urls = {'RW1':"https://github.com/nasa/prog_models"}
+    #     with self.assertRaises(ConnectionError):
+    #         (desc, data) = nasa_battery.load_data(1)
 
     def test_nasa_cmapss_bad_url_download(self):
         from prog_models.datasets import nasa_cmapss


### PR DESCRIPTION
Fix issues with datasets, specifically:

* Update CMAPSS link. 
* Remove Battery data download. Currently battery data is only available on PHM Society's website, and they have the full dataset as one file. I'm going to upload them as split files to data.nasa.gov soon, and will add this functionality back when that's done
  * Also removed the associated tests