### PR TITLE
Hotfix v1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use the following to cite this repository:
 @misc{2022_nasa_prog_models,
     author    = {Christopher Teubert and Matteo Corbetta and Chetan Kulkarni and Katelyn Jarvis and Matthew Daigle},
     title     = {Prognostics Models Python Package},
-    month     = October,
+    month     = December,
     year      = 2022,
     version   = {1.4},
     url       = {https://github.com/nasa/prog\_models}
@@ -42,7 +42,7 @@ Use the following to cite this repository:
 
 The corresponding reference should look like this:
 
-C. Teubert, C. Kulkarni, M. Corbetta, K. Jarvis, M. Daigle, Prognostics Model Python Package, v1.4, October 2022. URL https://github.com/nasa/prog_models.
+C. Teubert, C. Kulkarni, M. Corbetta, K. Jarvis, M. Daigle, Prognostics Model Python Package, v1.4, December 2022. URL https://github.com/nasa/prog_models.
 
 Alternatively, if using both prog_models and prog_algs, you can cite the combined package as
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQS = [
 
 setup(
     name = 'prog_models',
-    version = '1.4.3', #pkg_resources.require("prog_models")[0].version,
+    version = '1.4.4', #pkg_resources.require("prog_models")[0].version,
     description = 'The NASA Prognostic Model Package is a python modeling framework focused on defining and building models for prognostics (computation of remaining useful life) of engineering systems, and provides a set of prognostics models for select components developed within this framework, suitable for use in prognostics applications for these components.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/prog_models/__init__.py
+++ b/src/prog_models/__init__.py
@@ -5,4 +5,4 @@ from .prognostics_model import PrognosticsModel
 from .linear_model import LinearModel
 from .exceptions import ProgModelException, ProgModelInputException, ProgModelTypeError
 
-__version__ = '1.4.3'
+__version__ = '1.4.4'

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1001,7 +1001,7 @@ class PrognosticsModel(ABC):
         
         if not saved_outputs:
             # saved_outputs is empty, so it wasn't calculated in simulation - used cached result
-            saved_outputs = LazySimResult(self.output, saved_times, saved_states) 
+            saved_outputs = LazySimResult(self.__output, saved_times, saved_states) 
             saved_event_states = LazySimResult(self.event_state, saved_times, saved_states)
         else:
             saved_outputs = SimResult(saved_times, saved_outputs, _copy=False)

--- a/src/prog_models/utils/containers.py
+++ b/src/prog_models/utils/containers.py
@@ -32,7 +32,7 @@ class DictLikeMatrixWrapper():
                     [data[key]] if key in data else [None] for key in keys
                 ], dtype=np.float64)
         else:
-            raise ProgModelTypeError(f"Input must be a dictionary or numpy array, not {type(data)}")     
+            raise ProgModelTypeError(f"Data must be a dictionary or numpy array, not {type(data)}")     
 
     def __reduce__(self):
         return (DictLikeMatrixWrapper, (self._keys, self.matrix))

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -720,6 +720,80 @@ class TestModels(unittest.TestCase):
         # With next_time
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, **{'save_freq': 1e-99, 'dt': next_time})
         self.assertEqual(len(times), 11)
+
+    def test_sim_measurement_noise(self):
+        m = MockProgModel(process_noise = 0.0, measurement_noise = 1)
+        def load(t, x=None):
+            return {'i1': 1, 'i2': 2.1}
+
+        ## Simulate
+        (times, inputs, states, outputs, event_states) = m.simulate_to(3.5, load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
+
+        # Check times
+        for t in range(0, 4):
+            self.assertAlmostEqual(times[t], t, 5)
+        self.assertEqual(len(times), 5)
+        self.assertAlmostEqual(times[-1], 3.5, 5) # Save last step (even though it's not on a savepoint)
+        
+        # Check inputs
+        self.assertEqual(len(inputs), 5)
+        for i in inputs:
+            i0 = {'i1': 1, 'i2': 2.1}
+            for key in i.keys():
+                self.assertEqual(i[key], i0[key], "Future loading error")
+
+        # Check states
+        self.assertEqual(len(states), 5)
+        a = [1, 2, 3, 4, 4.5]
+        c = [-3.2, -7.4, -11.6, -15.8, -17.9]
+        for (ai, ci, x) in zip(a, c, states):
+            self.assertAlmostEqual(x['a'], ai, 5)
+            self.assertEqual(x['b'], 5)
+            self.assertAlmostEqual(x['c'], ci, 5)
+
+        # Check outputs
+        self.assertEqual(len(outputs), 5)
+        o = [2.8, -0.4, -3.6, -6.8, -8.4]
+        for (oi, z) in zip(o, outputs): 
+            # Noise will make output not equal the expected
+            self.assertNotEqual(round(z['o1'], 6), round(oi, 6))
+
+        ## Now with no measurmeent Noise
+        m = MockProgModel(process_noise = 0.0, measurement_noise = 0.0)
+        def load(t, x=None):
+            return {'i1': 1, 'i2': 2.1}
+
+        ## Simulate
+        (times, inputs, states, outputs, event_states) = m.simulate_to(3.5, load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
+
+        # Check times
+        for t in range(0, 4):
+            self.assertAlmostEqual(times[t], t, 5)
+        self.assertEqual(len(times), 5)
+        self.assertAlmostEqual(times[-1], 3.5, 5) # Save last step (even though it's not on a savepoint)
+        
+        # Check inputs
+        self.assertEqual(len(inputs), 5)
+        for i in inputs:
+            i0 = {'i1': 1, 'i2': 2.1}
+            for key in i.keys():
+                self.assertEqual(i[key], i0[key], "Future loading error")
+
+        # Check states
+        self.assertEqual(len(states), 5)
+        a = [1, 2, 3, 4, 4.5]
+        c = [-3.2, -7.4, -11.6, -15.8, -17.9]
+        for (ai, ci, x) in zip(a, c, states):
+            self.assertAlmostEqual(x['a'], ai, 5)
+            self.assertEqual(x['b'], 5)
+            self.assertAlmostEqual(x['c'], ci, 5)
+
+        # Check outputs
+        self.assertEqual(len(outputs), 5)
+        o = [2.8, -0.4, -3.6, -6.8, -8.4]
+        for (oi, z) in zip(o, outputs): 
+            # Noise will make output not equal the expected
+            self.assertEqual(round(z['o1'], 6), round(oi, 6))
     
     def test_sim_prog(self):
         m = MockProgModel(process_noise = 0.0)

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -792,7 +792,7 @@ class TestModels(unittest.TestCase):
         self.assertEqual(len(outputs), 5)
         o = [2.8, -0.4, -3.6, -6.8, -8.4]
         for (oi, z) in zip(o, outputs): 
-            # Noise will make output not equal the expected
+            # Lack of noise will make output as expected
             self.assertEqual(round(z['o1'], 6), round(oi, 6))
     
     def test_sim_prog(self):


### PR DESCRIPTION
Fix issue with Measurement Noise in LazySimResult. When using LazySimResult, noise is not added to the output. Issue first identified here: https://github.com/nasa/prog_algs/issues/220. A test was added to ensure this continues working

Also, updated one of the error messages.