### PR TITLE
hotfix v1.4.5: Fix save pt behavior 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQS = [
 
 setup(
     name = 'prog_models',
-    version = '1.4.4', #pkg_resources.require("prog_models")[0].version,
+    version = '1.4.5', #pkg_resources.require("prog_models")[0].version,
     description = 'The NASA Prognostic Model Package is a python modeling framework focused on defining and building models for prognostics (computation of remaining useful life) of engineering systems, and provides a set of prognostics models for select components developed within this framework, suitable for use in prognostics applications for these components.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/prog_models/__init__.py
+++ b/src/prog_models/__init__.py
@@ -5,4 +5,4 @@ from .prognostics_model import PrognosticsModel
 from .linear_model import LinearModel
 from .exceptions import ProgModelException, ProgModelInputException, ProgModelTypeError
 
-__version__ = '1.4.4'
+__version__ = '1.4.5'

--- a/src/prog_models/models/experimental/__init__.py
+++ b/src/prog_models/models/experimental/__init__.py
@@ -1,0 +1,2 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -846,7 +846,6 @@ class PrognosticsModel(ABC):
         next_save = next(iterator)
         save_pt_index = 0
         save_pts = config['save_pts']
-        save_pts.append(1e99)  # Add last endpoint
 
         # confgure optional intermediate printing
         if config['print']:
@@ -891,7 +890,8 @@ class PrognosticsModel(ABC):
                 return dt
         elif dt_mode == 'auto':
             def next_time(t, x):
-                return min(dt, next_save-t, save_pts[save_pt_index]-t)
+                next_save_pt = save_pts[save_pt_index] if save_pt_index < len(save_pts) else float('inf')
+                return min(dt, next_save-t, next_save_pt-t)
         elif dt_mode != 'function':
             raise ProgModelInputException(f"'dt' mode {dt_mode} not supported. Must be 'constant', 'auto', or a function")
         
@@ -974,10 +974,12 @@ class PrognosticsModel(ABC):
             if (t >= next_save):
                 next_save = next(iterator)
                 update_all()
-                if (t >= save_pts[save_pt_index]):
+                if (save_pt_index < len(save_pts)) and (t >= save_pts[save_pt_index]):
                     # Prevent double saving when save_pt and save_freq align
                     save_pt_index += 1
-            elif (t >= save_pts[save_pt_index]):
+            elif (save_pt_index < len(save_pts)) and (t >= save_pts[save_pt_index]):
+                # (save_pt_index < len(save_pts)) covers when t is past the last savepoint
+                # Otherwise save_pt_index would be out of range
                 save_pt_index += 1
                 update_all()
 


### PR DESCRIPTION
This PR fixes an issue in DMD where 1e99 was appended to the end of save_pts, breaking this feature. 

The issue was originating from python's way of using references for objects. 1e99 was appended inside simulate_to_threshold, making the same change in kwargs, which effected the behavior in the larger scope of DMD. 

The fix moves away from appending 1e99 in favor of adding an additional check.

Bug was found by @kjjarvis 

Also added missing copyright