### PR TITLE
hotfix v1.4.5c Numpy compatability issues

### DIFF
--- a/src/prog_models/models/pneumatic_valve.py
+++ b/src/prog_models/models/pneumatic_valve.py
@@ -154,7 +154,7 @@ class PneumaticValveBase(prognostics_model.PrognosticsModel):
         "pDiff"  # pL-pR
     ]
     outputs = ["Q", "iB", "iT", "pB", "pT", "x"]
-    is_vectorized = True
+    is_vectorized = False
     default_parameters = {  # Set to defaults
         # Environmental Parameters
         'R': 8.314,  # Universal Gas Constant

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -1282,9 +1282,6 @@ class TestModels(unittest.TestCase):
             m.B = np.array([[0]]) # less column values per row
             m.matrixCheck()
         with self.assertRaises(AttributeError): 
-            m.B = np.array([[0, 1, 2], [0, 0]]) # one row has more columns than another
-            m.matrixCheck()
-        with self.assertRaises(AttributeError): 
             m.B = np.array([[0, 1], [1, 1], [2, 2]]) # extra row
             m.matrixCheck()
         with self.assertRaises(AttributeError): 
@@ -1323,9 +1320,6 @@ class TestModels(unittest.TestCase):
         with self.assertRaises(AttributeError):
             m.E = np.array([[], []]) # less column values per row
             m.matrixCheck()
-        with self.assertRaises(AttributeError): 
-            m.E = np.array([[0, 1, 2], [0]]) # one row has more columns than another
-            m.matrixCheck() 
         with self.assertRaises(AttributeError): 
             m.E = np.array([[0, 1], [0, 0], [2, 2]]) # extra row
             m.matrixCheck()

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -1269,9 +1269,6 @@ class TestModels(unittest.TestCase):
             m.A = np.array([[0], [0]]) # less column values per row
             m.matrixCheck()
         with self.assertRaises(AttributeError): 
-            m.A = np.array([[0, 1, 2], [0, 0]]) # one row has more columns than another
-            m.matrixCheck()
-        with self.assertRaises(AttributeError): 
             m.A = np.array([[0, 1], [0, 0], [2, 2]]) # extra row
             m.matrixCheck()
         with self.assertRaises(AttributeError): 

--- a/tests/test_pneumatic_valve.py
+++ b/tests/test_pneumatic_valve.py
@@ -16,6 +16,7 @@ class TestPneumaticValve(unittest.TestCase):
     def tearDown(self):
         sys.stdout = sys.__stdout__
 
+    @unittest.skip
     def test_pneumatic_valve_vectorized(self):
         m = PneumaticValveWithWear(process_noise= 0)    
 


### PR DESCRIPTION
This hotfix resolves a few compatibility issues related to the behavior of arrays in numpy v1.24.0 (identified in rc2). Specifically:
* Remove test for behavior of uneven array. Numpy now automatically raises an exception
* Remove vectorization of pneumatic valve. The gas flow equation no longer works correctly with vectorized states. 

Thank you @kjjarvis for identifying and helping to resolve these bugs.