### PR TITLE
Direct Model Interface

### DIFF
--- a/examples/direct_model.py
+++ b/examples/direct_model.py
@@ -33,7 +33,7 @@ def run_example():
             t_impact = -(x['v'] + np.sqrt(x['v']*x['v'] - 2*g*x['x']))/g
             # 0 = v0 - g*t
             t_falling = -x['v']/g
-            return {'impact': t_impact, 'falling': t_falling}
+            return {'falling': t_falling, 'impact': t_impact}
 
     # Note that adding *args and **kwargs is optional.
     # Having these arguments makes the function interchangeable with other models

--- a/examples/direct_model.py
+++ b/examples/direct_model.py
@@ -1,0 +1,57 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+
+"""
+This example demonstrates the Direct Models functionality. Direct models are models that directly estimate time of event from system state, rather than using state transition. This is useful for data-driven models that map from sensor data to time of event, and for physics-based models where state transition differential equations can be solved.
+
+Here a DirectThrownObject model is defined, extending the ThrownObject state transition model from the new_model example. This model is then initialized and used to estimate the time of event from the initial state.
+"""
+
+import time
+import numpy as np
+from prog_models.models import ThrownObject
+
+def run_example():
+    # Here is how estimating time of event works for a timeseries model
+    # TODO(CT): Time
+    m = ThrownObject()
+    x = m.initialize()
+    print(m.__class__.__name__, "(Direct Model)" if m.is_direct_model else "(Timeseries Model)")
+    tic = time.perf_counter()
+    print('Time of event: ', m.time_of_event(x, dt = 0.05))
+    toc = time.perf_counter()
+    print(f'execution: {(toc-tic)*1000:0.4f} milliseconds')
+
+    # Step 1: Define DirectModel
+    # In this case we're extending the ThrownObject model to include the  time_to_event method, defined in DirectModel
+    # In the case of thrown objects, we can solve the differential equation 
+    # to estimate the time at which the events occur.
+    class DirectThrownObject(ThrownObject):
+        def time_of_event(self, x, **kwargs):
+            # calculate time when object hits ground given x['x'] and x['v']
+            # 0 = x0 + v0*t - 0.5*g*t^2
+            g = self.parameters['g']
+            t_impact = -(x['v'] + np.sqrt(x['v']*x['v'] - 2*g*x['x']))/g
+            # 0 = v0 - g*t
+            t_falling = -x['v']/g
+            return {'impact': t_impact, 'falling': t_falling}
+
+    # Step 2: Now estimate time of event for a ThrownObject
+    m = DirectThrownObject()
+    x = m.initialize()  # Using Initial state
+    # Now instead of simulating to threshold, we can estimate it directly from the state, like so
+    print(m.__class__.__name__, "(Direct Model)" if m.is_direct_model else "(Timeseries Model)")
+    tic = time.perf_counter()
+    print('Time of event: ', m.time_of_event(x))
+    toc = time.perf_counter()
+    print(f'execution: {(toc-tic)*1000:0.4f} milliseconds')
+
+    # Notice that execution is MUCH faster for the direct model. 
+    # This is even more pronounced for events that occur later in the simulation.
+
+    # In this case, the DirectThrownObject has a defined next_state and output equation, 
+    # allowing it to be used with a state estimator (e..g, Particle Filter)
+
+# This allows the module to be executed directly 
+if __name__ == '__main__':
+    run_example()

--- a/examples/direct_model.py
+++ b/examples/direct_model.py
@@ -40,7 +40,7 @@ def run_example():
     m = DirectThrownObject()
     x = m.initialize()  # Using Initial state
     # Now instead of simulating to threshold, we can estimate it directly from the state, like so
-    print(m.__class__.__name__, "(Direct Model)" if m.is_direct_model else "(Timeseries Model)")
+    print('\n', m.__class__.__name__, "(Direct Model)" if m.is_direct_model else "(Timeseries Model)")
     tic = time.perf_counter()
     print('Time of event: ', m.time_of_event(x))
     toc = time.perf_counter()

--- a/examples/direct_model.py
+++ b/examples/direct_model.py
@@ -13,7 +13,6 @@ from prog_models.models import ThrownObject
 
 def run_example():
     # Here is how estimating time of event works for a timeseries model
-    # TODO(CT): Time
     m = ThrownObject()
     x = m.initialize()
     print(m.__class__.__name__, "(Direct Model)" if m.is_direct_model else "(Timeseries Model)")
@@ -27,7 +26,7 @@ def run_example():
     # In the case of thrown objects, we can solve the differential equation 
     # to estimate the time at which the events occur.
     class DirectThrownObject(ThrownObject):
-        def time_of_event(self, x, **kwargs):
+        def time_of_event(self, x, *args, **kwargs):
             # calculate time when object hits ground given x['x'] and x['v']
             # 0 = x0 + v0*t - 0.5*g*t^2
             g = self.parameters['g']
@@ -35,6 +34,10 @@ def run_example():
             # 0 = v0 - g*t
             t_falling = -x['v']/g
             return {'impact': t_impact, 'falling': t_falling}
+
+    # Note that adding *args and **kwargs is optional.
+    # Having these arguments makes the function interchangeable with other models
+    # which might have arguments or keyword arguments
 
     # Step 2: Now estimate time of event for a ThrownObject
     m = DirectThrownObject()

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -609,7 +609,8 @@ class PrognosticsModel(ABC):
         Returns:
             bool: if the model is a state transition model
         """
-        return type(self).next_state != PrognosticsModel.next_state or type(self).dx != PrognosticsModel.dx
+        has_overridden_transition = type(self).next_state != PrognosticsModel.next_state or type(self).dx != PrognosticsModel.dx
+        return has_overridden_transition and len(self.states) > 0
 
     @property
     def is_direct_model(self) -> bool:

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -728,7 +728,7 @@ class PrognosticsModel(ABC):
 
         return self.simulate_to_threshold(future_loading_eqn, first_output, **kwargs)
  
-    def simulate_to_threshold(self, future_loading_eqn : Callable = lambda t,x=None: {}, first_output = None, threshold_keys : list = None, **kwargs) -> namedtuple:
+    def simulate_to_threshold(self, future_loading_eqn : Callable = None, first_output = None, threshold_keys : list = None, **kwargs) -> namedtuple:
         """
         Simulate prognostics model until any or specified threshold(s) have been met
 
@@ -809,7 +809,9 @@ class PrognosticsModel(ABC):
         if first_output and not all(key in first_output for key in self.outputs):
             raise ProgModelInputException("Missing key in 'first_output', must have every key in model.outputs")
 
-        if not (callable(future_loading_eqn)):
+        if future_loading_eqn is None:
+            future_loading_eqn = lambda t,x=None: self.InputContainer({})
+        elif not (callable(future_loading_eqn)):
             raise ProgModelInputException("'future_loading_eqn' must be callable f(t)")
         
         if isinstance(threshold_keys, str):

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -611,7 +611,7 @@ class PrognosticsModel(ABC):
         """
         return type(self).time_of_event != PrognosticsModel.time_of_event
 
-    def time_of_event(self, x, **kwargs) -> dict:
+    def time_of_event(self, x, future_loading_eqn = lambda t,x=None: {}, **kwargs) -> dict:
         """
         Calculate the time at which each :term:`event` occurs (i.e., the event :term:`threshold` is met) from :term:`state`. time_of_event must be implemented by any direct model. For a state transition model, this returns the time at which threshold_met returns true for each event. A model that implements this is called a "direct model".
 
@@ -620,6 +620,8 @@ class PrognosticsModel(ABC):
         x : StateContainer
             state, with keys defined by model.states \n
             e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+        future_loading_eqn : callable, optional
+            Function of (t) -> z used to predict future loading (output) at a given time (t). Defaults to no outputs
 
         Returns
         ------------
@@ -627,12 +629,16 @@ class PrognosticsModel(ABC):
             time of each event, with keys defined by model.events \n
             e.g., time_of_event = {'impact': 8.2, 'falling': 4.077} given events = ['impact', 'falling']
 
+        Note
+        -----------
+        Also supports arguments from :py:meth:`simulate_to_threshold`
+
         See Also
         --------
         threshold_met
         """
         params = {
-            'future_loading_eqn': lambda t,x=None: {}
+            'future_loading_eqn': future_loading_eqn,
         }
         params.update(kwargs)
 

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -152,7 +152,7 @@ class PrognosticsModel(ABC):
         self.n_events = len(self.events)
 
         if not hasattr(self, 'outputs'):
-            raise ProgModelTypeError('Must have `outputs` attribute')
+            self.outputs = []
         try:
             iter(self.outputs)
         except TypeError:

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -602,6 +602,16 @@ class PrognosticsModel(ABC):
             for (key, event_state) in self.event_state(x).items()} 
 
     @property
+    def is_state_transition_model(self) -> bool:
+        """
+        If the model is a "state transition model" - i.e., a model that uses state transition differential equations to propogate state forward.
+
+        Returns:
+            bool: if the model is a state transition model
+        """
+        return type(self).next_state != PrognosticsModel.next_state or type(self).dx != PrognosticsModel.dx
+
+    @property
     def is_direct_model(self) -> bool:
         """
         If the model is a "direct model" - i.e., a model that directly estimates time of event from system state, rather than using state transition. This is useful for data-driven models that map from sensor data to time of event, and for physics-based models where state transition differential equations can be solved.

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -462,10 +462,9 @@ class PrognosticsModel(ABC):
 
     observables = performance_metrics  # For backwards compatibility
 
-    @abstractmethod
     def output(self, x):
         """
-        Calculate outputs given state
+        Calculate :term:`output` given state
 
         Parameters
         ----------
@@ -487,7 +486,11 @@ class PrognosticsModel(ABC):
         | x = m.initialize(u, z) # Initialize first state
         | z = m.output(x) # Returns m.OutputContainer({'z1': 2.2})
         """
-        return {}
+        if self.is_direct_model:
+            warn('This Direct Model does not support output estimation. Did you mean to call time_of_event?')
+        else:
+            warn('This model does not support output estimation.')
+        return self.OutputContainer({})
 
     def __output(self, x):
         """
@@ -598,7 +601,55 @@ class PrognosticsModel(ABC):
         return {key: event_state <= 0 \
             for (key, event_state) in self.event_state(x).items()} 
 
-    def simulate_to(self, time : float, future_loading_eqn : Callable, first_output = None, **kwargs) -> namedtuple:
+    @property
+    def is_direct_model(self) -> bool:
+        """
+        If the model is a "direct model" - i.e., a model that directly estimates time of event from system state, rather than using state transition. This is useful for data-driven models that map from sensor data to time of event, and for physics-based models where state transition differential equations can be solved.
+
+        Returns:
+            bool: if the model is a direct model
+        """
+        return type(self).time_of_event != PrognosticsModel.time_of_event
+
+    def time_of_event(self, x, **kwargs) -> dict:
+        """
+        Calculate the time at which each :term:`event` occurs (i.e., the event :term:`threshold` is met) from :term:`state`. time_of_event must be implemented by any direct model. For a state transition model, this returns the time at which threshold_met returns true for each event. A model that implements this is called a "direct model".
+
+        Parameters
+        ----------
+        x : StateContainer
+            state, with keys defined by model.states \n
+            e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+
+        Returns
+        ------------
+        time_of_event : dict
+            time of each event, with keys defined by model.events \n
+            e.g., time_of_event = {'impact': 8.2, 'falling': 4.077} given events = ['impact', 'falling']
+
+        See Also
+        --------
+        threshold_met
+        """
+        params = {
+            'future_loading_eqn': lambda t,x=None: {}
+        }
+        params.update(kwargs)
+
+        threshold_keys = self.events.copy()
+        t = 0
+        time_of_event = {}
+        while len(threshold_keys) > 0:
+            result = self.simulate_to_threshold(x = x, t0 = t, **params)
+            for key, value in result.event_states[-1].items():
+                if value <= 0 and key not in time_of_event:
+                    threshold_keys.remove(key)
+                    time_of_event[key] = result.times[-1]
+            x = result.states[-1]
+            t = result.times[-1]
+        return time_of_event
+
+    def simulate_to(self, time : float, future_loading_eqn : Callable = lambda t,x=None: {}, first_output = None, **kwargs) -> namedtuple:
         """
         Simulate prognostics model for a given number of seconds
 
@@ -611,10 +662,6 @@ class PrognosticsModel(ABC):
             Function of (t) -> z used to predict future loading (output) at a given time (t)
         first_output : OutputContainer, optional
             First measured output, needed to initialize state for some classes. Can be omitted for classes that don't use this
-        options: kwargs, optional
-            Configuration options for the simulation \n
-            Note: configuration of the model is set through model.parameters \n
-            Supported parameters: see `simulate_to_threshold`
         
         Returns
         -------
@@ -632,6 +679,9 @@ class PrognosticsModel(ABC):
         Raises
         ------
         ProgModelInputException
+
+        Note:
+            See simulate_to_threshold for supported keyword arguments
 
         See Also
         --------
@@ -661,7 +711,7 @@ class PrognosticsModel(ABC):
 
         return self.simulate_to_threshold(future_loading_eqn, first_output, **kwargs)
  
-    def simulate_to_threshold(self, future_loading_eqn : Callable, first_output = None, threshold_keys : list = None, **kwargs) -> namedtuple:
+    def simulate_to_threshold(self, future_loading_eqn : Callable = lambda t,x=None: {}, first_output = None, threshold_keys : list = None, **kwargs) -> namedtuple:
         """
         Simulate prognostics model until any or specified threshold(s) have been met
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -12,6 +12,7 @@ from .test_datasets import main as datasets_main
 from .test_powertrain import main as powertrain_main
 from .test_surrogates import main as surrogates_main
 from .test_data_model import main as lstm_main
+from .test_direct import main as direct_main
 
 from io import StringIO
 import matplotlib.pyplot as plt
@@ -48,6 +49,11 @@ if __name__ == '__main__':
     # Run tests individually to test them and make sure they can be executed individually
     try:
         base_models_main()
+    except Exception:
+        was_successful = False
+
+    try:
+        direct_main()
     except Exception:
         was_successful = False
 

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -265,20 +265,14 @@ class TestModels(unittest.TestCase):
         m = missing_inputs()
         self.assertEqual(len(m.inputs), 0)
 
-        try: 
-            m = missing_outputs()
-            self.fail("Should not have worked, missing 'outputs'")
-        except ProgModelTypeError:
-            pass
+        m = missing_outputs()
+        self.assertEqual(len(m.outputs), 0)
 
         m = missing_initiialize()
         # Should work- initialize is now optional
 
-        try: 
-            m = missing_output()
-            self.fail("Should not have worked, missing 'output' method")
-        except TypeError:
-            pass
+        m = missing_output()
+        # Should work- output is now optional
 
     def __noise_test(self, noise_key, dist_key, keys):
         m = MockProgModel(**{noise_key: 0.0})

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,0 +1,123 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+
+from io import StringIO
+import numpy as np
+import sys
+import time
+import unittest
+
+from prog_models import PrognosticsModel
+from prog_models.models import ThrownObject
+
+class TestDirect(unittest.TestCase):
+    def setUp(self):
+        # set stdout (so it wont print)
+        sys.stdout = StringIO()
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+
+    def test_inherited_direct(self):
+        m = ThrownObject()
+        self.assertFalse(m.is_direct_model)
+
+        x = m.initialize()
+        tic = time.perf_counter()
+        m.time_of_event(x, dt = 0.05)
+        toc = time.perf_counter()
+        t_nondirect = toc - tic
+
+        class DirectThrownObject(ThrownObject):
+            def time_of_event(self, x, **kwargs):
+                # calculate time when object hits ground given x['x'] and x['v']
+                # 0 = x0 + v0*t - 0.5*g*t^2
+                g = self.parameters['g']
+                t_impact = -(x['v'] + np.sqrt(x['v']*x['v'] - 2*g*x['x']))/g
+                # 0 = v0 - g*t
+                t_falling = -x['v']/g
+                return {'impact': t_impact, 'falling': t_falling}
+
+        m_direct = DirectThrownObject()
+        x = m_direct.initialize()
+        self.assertTrue(m_direct.is_direct_model)
+        tic = time.perf_counter()
+        m_direct.time_of_event(x, dt=0.05)
+        toc = time.perf_counter()
+        t_direct = toc-tic
+        # Direct should be at least 10x faster
+        self.assertLess(t_direct, t_nondirect/10)
+
+        # Direct should have same events, states, inputs, outputs as non-direct 
+        self.assertListEqual(m_direct.events, m.events)
+        self.assertListEqual(m_direct.states, m.states)
+        self.assertListEqual(m_direct.inputs, m.inputs)
+        self.assertListEqual(m_direct.outputs, m.outputs)
+
+        # State Transition, Output, etc. should still work.
+        u = m_direct.InputContainer({})
+        x_direct = m_direct.next_state(x, u, dt=0.05)
+        x = m.next_state(x, u, dt=0.05)
+        self.assertEqual(x, x_direct)
+        z_direct = m_direct.output(x)
+        self.assertSetEqual(set(list(z_direct.keys())), set(m_direct.outputs))
+        z = m.output(x)
+        self.assertEqual(z, z_direct)
+        es = m_direct.event_state(x)
+        self.assertSetEqual(set(list(es.keys())), set(m_direct.events))
+
+    def test_non_inherited_direct(self):
+        # Test case where direct model is not inherited from state transition model and therefore ONLY has direct functionality
+        class DirectInheritedThrownObject(ThrownObject):
+            def time_of_event(self, x, **kwargs):
+                # calculate time when object hits ground given x['x'] and x['v']
+                # 0 = x0 + v0*t - 0.5*g*t^2
+                g = self.parameters['g']
+                t_impact = -(x['v'] + np.sqrt(x['v']*x['v'] - 2*g*x['x']))/g
+                # 0 = v0 - g*t
+                t_falling = -x['v']/g
+                return {'impact': t_impact, 'falling': t_falling}
+
+        class DirectNonInheritedThrownObject(PrognosticsModel):
+            states = ['x', 'v']
+            events = ['impact', 'falling']
+            default_parameters = {
+                'g': -9.81,
+            }
+            def time_of_event(self, x, **kwargs):
+                # calculate time when object hits ground given x['x'] and x['v']
+                # 0 = x0 + v0*t - 0.5*g*t^2
+                g = self.parameters['g']
+                t_impact = -(x['v'] + np.sqrt(x['v']*x['v'] - 2*g*x['x']))/g
+                # 0 = v0 - g*t
+                t_falling = -x['v']/g
+                return {'impact': t_impact, 'falling': t_falling}
+
+        m_inherited = DirectInheritedThrownObject()
+        m_non_inherited = DirectNonInheritedThrownObject()
+        self.assertTrue(m_non_inherited.is_direct_model)
+
+        x = m_inherited.initialize()
+        # Time of event should work the same
+        self.assertEqual(m_inherited.time_of_event(x), m_non_inherited.time_of_event(x))
+
+        # Using output should warn
+        with self.assertWarns(UserWarning):
+            # Should warn that outputs are not supported
+            m_non_inherited.output(x)
+
+# This allows the module to be executed directly
+def run_tests():
+    unittest.main()
+    
+def main():
+    l = unittest.TestLoader()
+    runner = unittest.TextTestRunner()
+    print("\n\nTesting Direct models")
+    result = runner.run(l.loadTestsFromTestCase(TestDirect)).wasSuccessful()
+
+    if not result:
+        raise Exception("Failed test")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR introduces the concept of a "Direct Model". Direct models map from state to time of event directly without having to perform state transition.

Direct models are introduced through a new method time_of_event which returns the time of event for each event as a dictionary. For direct models this function is overwritten.

When this function is not overwritten-simulate to threshold is called to estimate this value using simulation. 

The pr also includes an example, which calls time of event for direct model and non-direct model. This PR also introduces a is_direct_model property which returns true if time_of_event is overwritten. Tests were also added for both a direct model inherited from a state transition model and one that isn't.

In order to support simple direct models, I had to make outputs optional. The tests are now updated accordingly. 