### PR TITLE
[Simple] Move Propeller Load Model

### DIFF
--- a/examples/composite_model.py
+++ b/examples/composite_model.py
@@ -7,46 +7,8 @@ Example illustrating how to use the CompositeModel class to create a composite m
 This example creates a composite model of a DC motor with an Electronic Speed Controller and a propeller load. The three composite models are interrelated. The created composite model describes the nature of these interconnections. The resulting powertrain model is then simulated forward with time and the results are plotted. 
 """
 
-from prog_models.models import DCMotor, ESC
-from prog_models import PrognosticsModel, CompositeModel
-
-# Callback for load Model- used below
-def update_Cq(params):
-    return {
-        'C_q': params['c_q'] * params['rho'] * pow(params['D'], 5)
-    }
-
-
-class PropellerLoad(PrognosticsModel):
-    """
-    This is a simple model of a propeller load. This model estimates load torque as a function of the rotational velocity. When the propeller is spinning faster, drag increases, and the propeller load on the torque increases.
-    """
-    inputs = ['v_rot']
-    states = ['t_l']
-    outputs = ['t_l']
-
-    param_callbacks = {
-        'c_q': [update_Cq],
-        'rho': [update_Cq],
-        'D': [update_Cq],
-    }
-
-    default_parameters = {
-        # Load parameters 
-        'c_q': 5.42e-7, # coefficient of torque (APC data, derived) [dimensionless]
-        'rho': 1.225, # (Kg/m^3)
-        'D': 0.381, # (m)
-
-        'x0': {
-            't_l': 0,
-        }
-    }
-
-    def next_state(self, x, u, dt):
-        return self.StateContainer({'t_l': self.parameters['C_q']*u['v_rot']**2})
-    
-    def output(self, x):
-        return x
+from prog_models.models import DCMotor, ESC, PropellerLoad
+from prog_models import CompositeModel
 
 def run_example():
     # First, lets define the composite models

--- a/src/prog_models/models/__init__.py
+++ b/src/prog_models/models/__init__.py
@@ -9,5 +9,6 @@ from .dcmotor import DCMotor
 from .dcmotor_singlephase import DCMotorSP
 from .esc import ESC
 from .powertrain import Powertrain
+from .propeller_load import PropellerLoad
 from .thrown_object import ThrownObject
 from .experimental.paris_law import ParisLawCrackGrowth

--- a/src/prog_models/models/propeller_load.py
+++ b/src/prog_models/models/propeller_load.py
@@ -1,6 +1,8 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
+import numpy as np
+
 from .. import PrognosticsModel
 
 def update_Cq(params):
@@ -33,6 +35,10 @@ class PropellerLoad(PrognosticsModel):
         'x0': {
             't_l': 0,
         }
+    }
+
+    state_limits = {
+        't_l': (0, np.inf),
     }
 
     def next_state(self, x, u, dt):

--- a/src/prog_models/models/propeller_load.py
+++ b/src/prog_models/models/propeller_load.py
@@ -1,0 +1,42 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+
+from .. import PrognosticsModel
+
+def update_Cq(params):
+    return {
+        'C_q': params['c_q'] * params['rho'] * pow(params['D'], 5)
+    }
+
+class PropellerLoad(PrognosticsModel):
+    """
+    This is a simple model of a propeller load. This model estimates load torque as a function of the rotational velocity. When the propeller is spinning faster, drag increases, and the propeller load on the torque increases.
+
+    This model is typically used with the esc and dcmotor models to simulate a motor and propeller system.
+    """
+    inputs = ['v_rot']
+    states = ['t_l']
+    outputs = ['t_l']
+
+    param_callbacks = {
+        'c_q': [update_Cq],
+        'rho': [update_Cq],
+        'D': [update_Cq],
+    }
+
+    default_parameters = {
+        # Load parameters 
+        'c_q': 5.42e-7, # coefficient of torque (APC data, derived) [dimensionless]
+        'rho': 1.225, # (Kg/m^3)
+        'D': 0.381, # (m)
+
+        'x0': {
+            't_l': 0,
+        }
+    }
+
+    def next_state(self, x, u, dt):
+        return self.StateContainer({'t_l': self.parameters['C_q']*u['v_rot']**2})
+    
+    def output(self, x):
+        return x

--- a/src/prog_models/models/propeller_load.py
+++ b/src/prog_models/models/propeller_load.py
@@ -10,6 +10,7 @@ def update_Cq(params):
         'C_q': params['c_q'] * params['rho'] * pow(params['D'], 5)
     }
 
+
 class PropellerLoad(PrognosticsModel):
     """
     This is a simple model of a propeller load. This model estimates load torque as a function of the rotational velocity. When the propeller is spinning faster, drag increases, and the propeller load on the torque increases.

--- a/tests/test_powertrain.py
+++ b/tests/test_powertrain.py
@@ -26,10 +26,10 @@ class TestPowertrain(unittest.TestCase):
         # Check state transition
         x = m.next_state(x0, m.InputContainer({'v_rot': 2}), None)
         self.assertSetEqual(set(x.keys()), {'t_l'})
-        self.assertEqual(x['t_l'], m.parameters['t_l'] * 4)
+        self.assertEqual(x['t_l'], m.parameters['C_q'] * 4)
 
         x = m.next_state(x0, m.InputContainer({'v_rot': -2}), None)
-        self.assertEqual(x['t_l'], m.parameters['t_l'] * 4)
+        self.assertEqual(x['t_l'], m.parameters['C_q'] * 4)
 
         # Check output
         z = m.output(x)
@@ -37,7 +37,7 @@ class TestPowertrain(unittest.TestCase):
         self.assertEqual(z['t_l'], x['t_l'])
 
         # Events
-        self.assertSetEqual(set(m.events), {})
+        self.assertSetEqual(set(m.events), set())
 
         # State limits
         x_limited = m.apply_limits(m.StateContainer({'t_l': -1}))

--- a/tests/test_powertrain.py
+++ b/tests/test_powertrain.py
@@ -4,7 +4,7 @@ from io import StringIO
 import sys
 import unittest
 
-from prog_models.models import ESC, DCMotor, Powertrain
+from prog_models.models import ESC, DCMotor, Powertrain, PropellerLoad
 
 
 class TestPowertrain(unittest.TestCase):
@@ -14,7 +14,43 @@ class TestPowertrain(unittest.TestCase):
 
     def tearDown(self):
         sys.stdout = sys.__stdout__
-    
+        
+    def test_propeller_load(self):
+        m = PropellerLoad()
+
+        # initial state
+        x0 = m.initialize()
+        self.assertSetEqual(set(x0.keys()), {'t_l'})
+        self.assertEqual(x0['t_l'], 0)
+
+        # Check state transition
+        x = m.next_state(x0, m.InputContainer({'v_rot': 2}), None)
+        self.assertSetEqual(set(x.keys()), {'t_l'})
+        self.assertEqual(x['t_l'], m.parameters['t_l'] * 4)
+
+        x = m.next_state(x0, m.InputContainer({'v_rot': -2}), None)
+        self.assertEqual(x['t_l'], m.parameters['t_l'] * 4)
+
+        # Check output
+        z = m.output(x)
+        self.assertSetEqual(set(z.keys()), {'t_l'})
+        self.assertEqual(z['t_l'], x['t_l'])
+
+        # Events
+        self.assertSetEqual(set(m.events), {})
+
+        # State limits
+        x_limited = m.apply_limits(m.StateContainer({'t_l': -1}))
+        self.assertEqual(x_limited['t_l'], 0)
+
+        # Updating derived parameters 
+        c_q = m.parameters['C_q']
+        m.parameters['c_q'] *= 2
+        self.assertEqual(m.parameters['C_q'], c_q * 2)
+
+        m.parameters['D'] = 1
+        self.assertEqual(m.parameters['C_q'], m.parameters['c_q'] * m.parameters['rho'])
+
     def test_powertrain(self):
         esc = ESC()
         motor = DCMotor()


### PR DESCRIPTION
Very Simple PR. I just moved the propeller load model from the composite example to the prog_models.models package (Implements ticket #478, idea by kjjarvis)