### PR TITLE
Add ability to estimate the size of a model 

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -17,6 +17,7 @@ from .utils import ProgressBar
 from .utils.containers import DictLikeMatrixWrapper
 from .utils.parameters import PrognosticsModelParameters
 from .utils.serialization import *
+from .utils.size import getsizeof
 
 
 class PrognosticsModel(ABC):
@@ -1138,6 +1139,9 @@ class PrognosticsModel(ABC):
             saved_outputs, 
             saved_event_states
         )
+
+    def __sizeof__(self):
+        return getsizeof(self)
 
     def calc_error(self, times : List[float], inputs : List[dict], outputs : List[dict], **kwargs) -> float:
         """Calculate Mean Squared Error (MSE) between simulated and observed

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -11,13 +11,13 @@ import numpy as np
 from typing import Callable, Iterable, List
 from warnings import warn
 
-from .exceptions import ProgModelInputException, ProgModelTypeError, ProgModelException, ProgModelStateLimitWarning
-from .sim_result import SimResult, LazySimResult
-from .utils import ProgressBar
-from .utils.containers import DictLikeMatrixWrapper
-from .utils.parameters import PrognosticsModelParameters
-from .utils.serialization import *
-from .utils.size import getsizeof
+from prog_models.exceptions import ProgModelInputException, ProgModelTypeError, ProgModelException, ProgModelStateLimitWarning
+from prog_models.sim_result import SimResult, LazySimResult
+from prog_models.utils import ProgressBar
+from prog_models.utils.containers import DictLikeMatrixWrapper
+from prog_models.utils.parameters import PrognosticsModelParameters
+from prog_models.utils.serialization import *
+from prog_models.utils.size import getsizeof
 
 
 class PrognosticsModel(ABC):

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -57,7 +57,7 @@ class PrognosticsModelParameters(UserDict):
     def __deepcopy__(self):
         return self.__class__(self._m, self.data, self.callbacks, _copy=True)
 
-    def __setitem__(self, key : str, value : float, _copy : bool = True) -> None:
+    def __setitem__(self, key : str, value : float, _copy : bool = False) -> None:
         """Set model configuration, overrides dict.__setitem__()
 
         Args:

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -8,10 +8,10 @@ from numbers import Number
 import types
 from typing import Callable
 
+from prog_models.utils.noise_functions import measurement_noise_functions, process_noise_functions
+from prog_models.utils.serialization import *
 from prog_models.utils.size import getsizeof
-from .noise_functions import measurement_noise_functions, process_noise_functions
-from .serialization import *
-from ..exceptions import ProgModelTypeError
+from prog_models.exceptions import ProgModelTypeError
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING: # Fix circular import issue in PrognosticsModelParameters init

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -8,6 +8,7 @@ from numbers import Number
 import types
 from typing import Callable
 
+from prog_models.utils.size import getsizeof
 from .noise_functions import measurement_noise_functions, process_noise_functions
 from .serialization import *
 from ..exceptions import ProgModelTypeError
@@ -43,6 +44,9 @@ class PrognosticsModelParameters(UserDict):
                 for callback in callbacks[key]:
                     changes = callback(self)
                     self.update(changes)
+    
+    def __sizeof__(self):
+        return getsizeof(self)
 
     def copy(self):
         return self.__class__(self._m, self.data, self.callbacks, _copy=False)

--- a/src/prog_models/utils/size.py
+++ b/src/prog_models/utils/size.py
@@ -1,0 +1,83 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+
+from itertools import chain
+import numpy as np
+
+from prog_models.sim_result import SimResult
+from prog_models.utils.containers import DictLikeMatrixWrapper
+
+
+def dict_handler(d):
+    # Handle dictionaries
+    return chain.from_iterable(d.items())
+
+
+def object_handler(o):
+    # Handle general objects
+    return chain.from_iterable(o.__dict__.items())
+
+
+# Set of handlers that describe how to estimate the size of the payload of an object of a given type
+# in format {type: handler}
+all_handlers = {tuple: iter,
+                list: iter,
+                np.ndarray: lambda a: iter(list(a.flat)),
+                dict: dict_handler,
+                set: iter,
+                frozenset: iter,
+                DictLikeMatrixWrapper: dict_handler,
+                SimResult: iter
+                }
+
+
+def getsizeof(o):
+    """
+    Return the size of object in bytes.
+
+    Args:
+        o (Any): Object to find size of
+
+    Returns:
+        int: Size in bytes of object
+    """
+    seen = set()  # track which object id's have already been seen
+
+    # Add Custom handler for prog_models objects that import this file
+    # This is to avoid circular imports
+    from prog_models import PrognosticsModel
+    from prog_models.utils.parameters import PrognosticsModelParameters
+    all_handlers[PrognosticsModelParameters] = object_handler
+    all_handlers[PrognosticsModel] = object_handler
+
+    def sizeof(o):
+        """
+        Internal (recursive) function to find size of object.
+
+        This is defined in here so it can use the higher-scoped variable `seen`
+
+        Args:
+            o (Any): Object to find size of
+
+        Returns:
+            int: Size in bytes of object
+        """
+        if id(o) in seen:
+            # Object has already been counted, dont count twice
+            # This is to avoid circular references
+            return 0
+        seen.add(id(o))
+
+        # Get size of object itself
+        s = object.__sizeof__(o)
+
+        # Try handlers
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                return s
+
+        # If no handler found, return size of object itself (no recursion)
+        # This is mostly for simple types (e.g., int) that don't have a payload
+        return s
+    return sizeof(o)

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -154,6 +154,40 @@ class TestModels(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, **{'dt': 0.5, 'save_freq': 1.0})
         self.assertAlmostEqual(times[-1], 5.0, 5)
 
+    def test_size(self):
+        m = MockProgModel()
+        size = sys.getsizeof(m)
+        self.assertLess(size, 7500)
+
+        # Adding a parameter
+        m.parameters['test'] = 8675309
+        size2 = sys.getsizeof(m)
+
+        # Check that size increases
+        self.assertLess(size, size2)
+
+        # Size difference should be slightly more than the size of key & value
+        # The difference is overhead for the dict
+        # Note- have to use an uncommon number for this to work
+        # This is because of python's memory allocation
+        diff = size2 - size
+        sum_of_parts = sys.getsizeof('test') + sys.getsizeof(8675309)
+        self.assertLess(sum_of_parts, diff)
+        self.assertLess(diff-sum_of_parts, 100)
+
+        # Adding other attributes
+        m._test_value = 123456789
+        size3 = sys.getsizeof(m)
+
+        # Check that size increases
+        self.assertLess(size2, size3)
+
+        # Size difference should be slightly more than the size of key & value
+        # The difference is overhead for the dict
+        diff = size3 - size2
+        sum_of_parts = sys.getsizeof('_test_value') + sys.getsizeof(123456789)
+        self.assertLess(sum_of_parts, diff)
+        self.assertLess(diff-sum_of_parts, 100)
 
     def test_templates(self):
         import prog_model_template

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -189,6 +189,37 @@ class TestModels(unittest.TestCase):
         self.assertLess(sum_of_parts, diff)
         self.assertLess(diff-sum_of_parts, 100)
 
+        # Add list into parameters
+        m.parameters['test_list'] = [79534, 84392, 93333, -243934, 23233]
+        size4 = sys.getsizeof(m)
+
+        # Check that size increases
+        self.assertLess(size3, size4)
+
+        # Size difference should be slightly more than the size of key & value
+        # The difference is overhead for the dict
+        diff = size4 - size3
+        sum_of_parts = sys.getsizeof('test_list') + sys.getsizeof([79534, 84392, 93333, -243934, 23233])
+        self.assertLess(sum_of_parts, diff)
+
+        # Note that adding as a parameter is expected to be similar
+        # This is because it uses the same logic in the callback
+
+        # Adding something already seen
+        m.parameters['recursive'] = m
+        size5 = sys.getsizeof(m)
+
+        # Check that size increases (for key)
+        self.assertLess(size4, size5)
+
+        # Size difference should be slightly more than the size of key
+        # size of value is skipped because it is already seen
+        # The difference is overhead for the dict
+        diff = size5 - size4
+        sum_of_parts = sys.getsizeof('recursive')
+        self.assertLess(sum_of_parts, diff)
+        self.assertLess(diff-sum_of_parts, 100)
+
     def test_templates(self):
         import prog_model_template
         m = prog_model_template.ProgModelTemplate()


### PR DESCRIPTION
This is useful for benchmarking and requested by the TechEdSat effort. Now sys.getsizeof works properly for PrognosticsModels and Parameters. 

I added two tests that show that adding to the model increases the size by the expected amount. This is challenging because the size of overhead is python version and computer-dependent. To handle this the tests pass so long as the overhead is "reasonable".

This change also includes changing the default in parameters to "not copy" this allows python's optimizations to stay in place. I originally changed this to allow for test of repeated objects in parameters, but it is also a good change generally. 

This implements the first part of #493. __sizeof__ wasn't implemented for the containers (SimResult, SimResults, and *Containers) because they will soon be replaced as part of #482. Note: #493 is to be kept open for this reason. 