### PR TITLE
Adding serialization tests to __main__ for tests

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -14,6 +14,7 @@ from .test_surrogates import main as surrogates_main
 from .test_data_model import main as lstm_main
 from .test_direct import main as direct_main
 from .test_linear_model import main as linear_main
+from .test_serialization import main as serialization_main
 
 from io import StringIO
 import matplotlib.pyplot as plt
@@ -115,6 +116,11 @@ if __name__ == '__main__':
 
     try:
         linear_main()
+    except Exception:
+        was_successful = False
+
+    try:
+        serialization_main()()
     except Exception:
         was_successful = False
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         was_successful = False
 
     try:
-        serialization_main()()
+        serialization_main()
     except Exception:
         was_successful = False
 


### PR DESCRIPTION
The serialization tests were not included in the __main__ script for the tests. This has been fixed.  