### PR TITLE
Move next_state into utils

### DIFF
--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -16,6 +16,7 @@ from prog_models.sim_result import SimResult, LazySimResult
 from prog_models.utils import ProgressBar
 from prog_models.utils import calc_error
 from prog_models.utils.containers import DictLikeMatrixWrapper
+from prog_models.utils.next_state import euler_next_state, rk4_next_state, euler_next_state_wrapper, rk4_next_state_wrapper
 from prog_models.utils.parameters import PrognosticsModelParameters
 from prog_models.utils.serialization import CustomEncoder, custom_decoder
 from prog_models.utils.size import getsizeof
@@ -412,51 +413,6 @@ class PrognosticsModel(ABC):
                 warn("State {} limited to {} (was {})".format(key, limit[1], x[key]), ProgModelStateLimitWarning)
                 x[key] = np.minimum(x[key], limit[1])
         return x
-
-    def __next_state(self, x, u, dt: float):
-        """
-        State transition equation: Calls next_state(), calculating the next state, and then adds noise
-
-        Parameters
-        ----------
-        x : StateContainer
-            state, with keys defined by model.states \n
-            e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
-        u : InputContainer
-            Inputs, with keys defined by model.inputs \n
-            e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
-        dt : float
-            Timestep size in seconds (≥ 0) \n
-            e.g., dt = 0.1
-
-        Returns
-        -------
-        x : StateContainer
-            Next state, with keys defined by model.states
-            e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
-
-        Example
-        -------
-        | m = PrognosticsModel() # Replace with specific model being simulated
-        | u = m.InputContainer({'u1': 3.2})
-        | z = m.OutputContainer({'z1': 2.2})
-        | x = m.initialize(u, z) # Initialize first state
-        | x = m.__next_state(x, u, 0.1) # Returns state, with noise, at 3.1 seconds given input u
-
-        See Also
-        --------
-        next_state
-
-        Note
-        ----
-        A model should not overwrite '__next_state'
-        A model should overwrite either `next_state` or `dx`. Override `dx` for continuous models, and `next_state` for discrete, where the behavior cannot be described by the first derivative.
-        """
-        # Calculate next state and add process noise
-        next_state = self.apply_process_noise(self.next_state(x, u, dt), dt)
-
-        # Apply Limits
-        return self.apply_limits(next_state)
 
     def performance_metrics(self, x) -> dict:
         """
@@ -927,7 +883,6 @@ class PrognosticsModel(ABC):
             x = self.StateContainer(x)
         
         # Optimization
-        next_state = self.__next_state
         output = self.__output
         threshold_met_eqn = self.threshold_met
         event_state = self.event_state
@@ -1031,19 +986,6 @@ class PrognosticsModel(ABC):
                 u = future_loading_eqn(t, x)
                 return self.InputContainer(u)
 
-        if not isinstance(self.next_state(x.copy(), u, dt0), DictLikeMatrixWrapper):
-            # Wrapper around next_state
-            def next_state(x, u, dt):
-                # Calculate next state, and convert
-                x_new = self.next_state(x, u, dt)
-                x_new = self.StateContainer(x_new)
-
-                # Calculate next state and add process noise
-                next_state = self.apply_process_noise(x_new, dt)
-
-                # Apply Limits
-                return self.apply_limits(next_state)
-
         if not isinstance(self.output(x), DictLikeMatrixWrapper):
             # Wrapper around the output equation
             def output(x):
@@ -1072,21 +1014,16 @@ class PrognosticsModel(ABC):
             apply_limits = self.apply_limits
             apply_process_noise = self.apply_process_noise
             StateContainer = self.StateContainer
-            def next_state(x, u, dt):
-                dx1 = StateContainer(dx(x, u))
-                
-                x2 = StateContainer({key: x[key] + dt*dx_i/2 for key, dx_i in dx1.items()})
-                dx2 = dx(x2, u)
-
-                x3 = StateContainer({key: x[key] + dt*dx_i/2 for key, dx_i in dx2.items()})
-                dx3 = dx(x3, u)
-                
-                x4 = StateContainer({key: x[key] + dt*dx_i for key, dx_i in dx3.items()})   
-                dx4 = dx(x4, u)
-
-                x = StateContainer({key: x[key]+ dt/3*(dx1[key]/2 + dx2[key] + dx3[key] + dx4[key]/2) for key in dx1.keys()})
-                return apply_limits(apply_process_noise(x))
-        elif config['integration_method'].lower() != 'euler':
+            if not isinstance(self.dx(x.copy(), u), DictLikeMatrixWrapper):
+                next_state = rk4_next_state
+            else:
+                next_state = rk4_next_state_wrapper
+        elif config['integration_method'].lower() == 'euler':
+            if not isinstance(self.next_state(x.copy(), u, dt0), DictLikeMatrixWrapper):
+                next_state = euler_next_state_wrapper
+            else:
+                next_state = euler_next_state
+        else:
             raise ProgModelInputException(f"'integration_method' mode {config['integration_method']} not supported. Must be 'euler' or 'rk4'")
        
         while t < horizon:
@@ -1096,7 +1033,7 @@ class PrognosticsModel(ABC):
             # This is sometimes referred to as 'leapfrog integration'
             u = load_eqn(t, x)
             t = t + dt/2
-            x = next_state(x, u, dt)
+            x = next_state(self, x, u, dt)
 
             # Save if at appropriate time
             if (t >= next_save):

--- a/src/prog_models/utils/next_state.py
+++ b/src/prog_models/utils/next_state.py
@@ -1,0 +1,146 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration.  All Rights Reserved.
+
+def euler_next_state(model, x, u, dt: float):
+    """
+    State transition equation using simple euler integration: Calls next_state(), calculating the next state, and then adds noise and applies limits
+
+    Parameters
+    ----------
+    x : StateContainer
+        state, with keys defined by model.states \n
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+    u : InputContainer
+        Inputs, with keys defined by model.inputs \n
+        e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
+    dt : float
+        Timestep size in seconds (≥ 0) \n
+        e.g., dt = 0.1
+
+    Returns
+    -------
+    x : StateContainer
+        Next state, with keys defined by model.states
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+
+    See Also
+    --------
+    PrognosticsModel.next_state
+    """
+    # Calculate next state and add process noise
+    next_state = model.apply_process_noise(model.next_state(x, u, dt), dt)
+
+    # Apply Limits
+    return model.apply_limits(next_state)
+
+def euler_next_state_wrapper(model, x, u, dt: float):
+    """
+    State transition equation using simple euler integration: Calls next_state(), calculating the next state, and then adds noise and applies limits
+
+    Parameters
+    ----------
+    x : StateContainer
+        state, with keys defined by model.states \n
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+    u : InputContainer
+        Inputs, with keys defined by model.inputs \n
+        e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
+    dt : float
+        Timestep size in seconds (≥ 0) \n
+        e.g., dt = 0.1
+
+    Returns
+    -------
+    x : StateContainer
+        Next state, with keys defined by model.states
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+
+    See Also
+    --------
+    PrognosticsModel.next_state
+    """
+    # Calculate next state and add process noise
+    next_state = model.StateContainer(model.next_state(x, u, dt))
+    next_state = model.apply_process_noise(next_state, dt)
+
+    # Apply Limits
+    return model.apply_limits(next_state)
+
+def rk4_next_state(model, x, u, dt: float):
+    """
+    State transition equation using rungekutta4 integration: Calls next_state(), calculating the next state, and then adds noise and applies limits
+
+    Parameters
+    ----------
+    x : StateContainer
+        state, with keys defined by model.states \n
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+    u : InputContainer
+        Inputs, with keys defined by model.inputs \n
+        e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
+    dt : float
+        Timestep size in seconds (≥ 0) \n
+        e.g., dt = 0.1
+
+    Returns
+    -------
+    x : StateContainer
+        Next state, with keys defined by model.states
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+
+    See Also
+    --------
+    PrognosticsModel.next_state
+    """
+    dx1 = model.StateContainer(model.dx(x, u))
+    x2 = x.matrix + dx1.matrix*dt/2
+    dx2 = model.dx(x2, u)
+
+    x3 = model.StateContainer({key: x[key] + dt*dx_i/2 for key, dx_i in dx2.items()})
+    dx3 = model.dx(x3, u)
+    
+    x4 = model.StateContainer({key: x[key] + dt*dx_i for key, dx_i in dx3.items()})
+    dx4 = model.dx(x4, u)
+
+    x = model.StateContainer({key: x[key] + dt/3*(dx1[key]/2 + dx2[key] + dx3[key] + dx4[key]/2) for key in dx1.keys()})
+    return model.apply_limits(model.apply_process_noise(x))
+
+def rk4_next_state_wrapper(model, x, u, dt: float):
+    """
+    State transition equation using rungekutta4 integration: Calls next_state(), calculating the next state, and then adds noise and applies limits
+
+    Parameters
+    ----------
+    x : StateContainer
+        state, with keys defined by model.states \n
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+    u : InputContainer
+        Inputs, with keys defined by model.inputs \n
+        e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
+    dt : float
+        Timestep size in seconds (≥ 0) \n
+        e.g., dt = 0.1
+
+    Returns
+    -------
+    x : StateContainer
+        Next state, with keys defined by model.states
+        e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+
+    See Also
+    --------
+    PrognosticsModel.next_state
+    """
+    dx1 = model.StateContainer(model.dx(x, u))
+                
+    x2 = model.StateContainer({key: x[key] + dt*dx_i/2 for key, dx_i in dx1.items()})
+    dx2 = model.dx(x2, u)
+
+    x3 = model.StateContainer({key: x[key] + dt*dx_i/2 for key, dx_i in dx2.items()})
+    dx3 = model.dx(x3, u)
+    
+    x4 = model.StateContainer({key: x[key] + dt*dx_i for key, dx_i in dx3.items()})
+    dx4 = model.dx(x4, u)
+
+    x = model.StateContainer({key: x[key] + dt/3*(dx1[key]/2 + dx2[key] + dx3[key] + dx4[key]/2) for key in dx1.keys()})
+    return model.apply_limits(model.apply_process_noise(x))


### PR DESCRIPTION
Small first step towards cleaning up prognostics_model.py. This change moves the state transition wrappers for different integration methods out of prognostics_model.py and into its own file

This change will also help support additional integration methods being worked on by partners. 