### PR TITLE
Linter Cleanup

### DIFF
--- a/examples/sim.py
+++ b/examples/sim.py
@@ -26,7 +26,7 @@ def run_example():
         elif (t < 1800):
             i = 4
         elif (t < 3000):
-            i = 2     
+            i = 2
         else:
             i = 3
         return batt.InputContainer({'i': i})

--- a/prog_model_template.py
+++ b/prog_model_template.py
@@ -16,7 +16,7 @@ from prog_models import PrognosticsModel
 
 # REPLACE THIS WITH DERIVED PARAMETER CALLBACKS (IF ANY)
 # See examples.derived_params
-# 
+#
 # Each function defines one or more derived parameters as a function of the other parameters.
 def example_callback(params):
     # Return format: dict of key: new value pair for at least one derived parameter
@@ -35,7 +35,7 @@ class ProgModelTemplate(PrognosticsModel):
 
     # REPLACE THE FOLLOWING LIST WITH EVENTS BEING PREDICTED
     events = [
-        'Example Event' 
+        'Example Event'
     ]
     
     # REPLACE THE FOLLOWING LIST WITH INPUTS (LOADING)
@@ -54,18 +54,18 @@ class ProgModelTemplate(PrognosticsModel):
 
     # REPLACE THE FOLLOWING LIST WITH OUTPUTS (MEASURED VALUES)
     outputs = [
-        'Example Output 1', 
-        'Example Output 2'  
+        'Example Output 1',
+        'Example Output 2' 
     ]
 
     # REPLACE THE FOLLOWING LIST WITH CONFIGURED PARAMETERS
-    # Note- everything required to configure the model 
-    # should be in parameters- this is to enable the serialization features 
+    # Note- everything required to configure the model
+    # should be in parameters- this is to enable the serialization features
     default_parameters = {  # Set default parameters
         'Example Parameter 1': 0,
         'Example Parameter 2': 3,
         'process_noise': 0.1,  # Process noise
-        'x0': {  # Initial state  
+        'x0': {  # Initial state
             'Examples State 1': 1.5,
             'Examples State 2': -935,
             'Examples State 3': 42.1,
@@ -85,7 +85,7 @@ class ProgModelTemplate(PrognosticsModel):
     # See examples.derived_params
     # Format: "trigger": [callbacks]
     # Where trigger is the parameter that the derived parameters are derived from.
-    # And callbacks are one or more callback functions that define parameters that are 
+    # And callbacks are one or more callback functions that define parameters that are
     # derived from that parameter
     # REPLACE THIS WITH ACTUAL DERIVED PARAMETER CALLBACKS
     param_callbacks = {
@@ -104,12 +104,12 @@ class ProgModelTemplate(PrognosticsModel):
     #     # ADD OPTIONS CHECKS HERE
 
     #     # e.g., Checking for required parameters
-    #     # if not 'required_param' in kwargs: 
+    #     # if not 'required_param' in kwargs:
     #     #   throw Exception;
 
     #     super().__init__(**kwargs) # Run Parent constructor
 
-    # Model state initialization - there are two ways to provide the logic to initialize model state. 
+    # Model state initialization - there are two ways to provide the logic to initialize model state.
     # 1. Provide the initial state in parameters['x0'], or
     # 2. Provide an Initialization function
     #
@@ -238,7 +238,7 @@ class ProgModelTemplate(PrognosticsModel):
         # NOTE: KEYS FOR z MATCH 'outputs' LIST ABOVE
         z = self.OutputContainer({
             'Example Output 1': 0.0,
-            'Example Output 2': 0.0  
+            'Example Output 2': 0.0
         })
 
         return z
@@ -268,7 +268,8 @@ class ProgModelTemplate(PrognosticsModel):
 
         return event_x
         
-    # Note: Thresholds met equation below is not strictly necessary. By default threshold_met will check if event_state is ≤ 0 for each event
+    # Note: Thresholds met equation below is not strictly necessary.
+    # By default threshold_met will check if event_state is ≤ 0 for each event
     def threshold_met(self, x):
         """
         For each event threshold, calculate if it has been met

--- a/src/prog_models/composite_model.py
+++ b/src/prog_models/composite_model.py
@@ -30,10 +30,10 @@ class CompositeModel(PrognosticsModel):
 
     Keyword Args:
         outputs (list[str]):
-            Model outputs in format "model_name.output_name". Must be subset of all outputs from models. If not provided, all outputs will be included. 
+            Model outputs in format "model_name.output_name". Must be subset of all outputs from models. If not provided, all outputs will be included.
     """
 
-    def __init__(self, models, connections = [], **kwargs):
+    def __init__(self, models, connections=[], **kwargs):
         # General Input Validation
         if not isinstance(models, Iterable):
             raise ValueError('The models argument must be a list')
@@ -55,7 +55,7 @@ class CompositeModel(PrognosticsModel):
         # Handle models
         for m in models:
             if isinstance(m, Iterable):
-                if len(m) != 2: 
+                if len(m) != 2:
                     raise ValueError('Each model tuple must be of the form (name: str, model). For example ("Batt1", BatteryElectroChem())')
                 if not isinstance(m[0], str):
                     raise ValueError('The first element of each model tuple must be a string')
@@ -95,8 +95,8 @@ class CompositeModel(PrognosticsModel):
         
         # Handle Connections
         kwargs['connections'] = []
-        self.__to_input_connections = {m_name : [] for m_name in self.model_names}
-        self.__to_state_connections = {m_name : [] for m_name in self.model_names}
+        self.__to_input_connections = {m_name: [] for m_name in self.model_names}
+        self.__to_state_connections = {m_name: [] for m_name in self.model_names}
 
         for connection in connections:
             # Input validation
@@ -143,7 +143,7 @@ class CompositeModel(PrognosticsModel):
         # Finish initialization
         super().__init__(**kwargs)
 
-    def initialize(self, u = {}, z = {}):
+    def initialize(self, u={}, z={}):
         if u is None:
             u = {}
         if z is None:

--- a/src/prog_models/data_models/__init__.py
+++ b/src/prog_models/data_models/__init__.py
@@ -6,7 +6,7 @@ from .dmd import DMDModel
 from .lstm_model import LSTMStateTransitionModel
 from .pce import PolynomialChaosExpansion, PCE
 
-SURROAGATE_METHOD_LOOKUP = {
+SURROGATE_METHOD_LOOKUP = {
     'dmd': DMDModel.from_model,
     'lstm': LSTMStateTransitionModel.from_model,
     'pce': PolynomialChaosExpansion.from_model,

--- a/src/prog_models/data_models/data_model.py
+++ b/src/prog_models/data_models/data_model.py
@@ -5,14 +5,14 @@ from abc import ABC, abstractclassmethod
 import numpy as np
 import sys
 
-from .. import PrognosticsModel
+from prog_models import PrognosticsModel
 
 
 class DataModel(PrognosticsModel, ABC):
     """
     .. versionadded:: 1.4.0
 
-    Abstract Base Class for all Data Models (e.g., :py:class:`LSTMStateTransitionModel`). Defines the interface and all common tools. To create a new Data-Driven model, first subclass this, then define the abstract methods from this class and :py:class:`prog_models.PrognosticsModel`. 
+    Abstract Base Class for all Data Models (e.g., :py:class:`LSTMStateTransitionModel`). Defines the interface and all common tools. To create a new Data-Driven model, first subclass this, then define the abstract methods from this class and :py:class:`prog_models.PrognosticsModel`.
 
     See Also:
         PrognosticsModel
@@ -24,25 +24,25 @@ class DataModel(PrognosticsModel, ABC):
         Create a Data Model from data. This class is overwritten by specific data-driven classes (e.g., :py:class:`LSTMStateTransitionModel`)
 
         Keyword Arguments:
-            times (list[list]): 
+            times (list[list]):
                 list of input data for use in data. Each element is the times for a single run of size (n_times)
-            inputs (list[np.array]): 
+            inputs (list[np.array]):
                 list of :term:`input` data for use in data. Each element is the inputs for a single run of size (n_times, n_inputs)
-            states (list[np.array]): 
+            states (list[np.array]):
                 list of :term:`state` data for use in data. Each element is the states for a single run of size (n_times, n_states)
-            outputs (list[np.array]): 
+            outputs (list[np.array]):
                 list of :term:`output` data for use in data. Each element is the outputs for a single run of size (n_times, n_outputs)
-            event_states (list[np.array]): 
+            event_states (list[np.array]):
                 list of :term:`event state` data for use in data. Each element is the event states for a single run of size (n_times, n_event_states)
             time_of_event (np.array):
                 Array of time of event data for use in data. Each element is the time of event for a single run of size (n_samples, n_events)
-            input_keys (list[str]): 
+            input_keys (list[str]):
                 List of :term:`input` keys
-            state_keys (list[str]): 
+            state_keys (list[str]):
                 List of :term:`state` keys
-            output_keys (list[str]): 
+            output_keys (list[str]):
                 List of :term:`output` keys
-            event_keys (list[str]): 
+            event_keys (list[str]):
                 List of :term:`event` keys
         
         See specific data class for more additional keyword arguments
@@ -64,17 +64,17 @@ class DataModel(PrognosticsModel, ABC):
 
     def __getstate__(self):
         # This is necessary to support pickling
-        # Override this, replacing the [] with any arguments from the constructor
+        # Override this, replacing the [] with any arguments from constructor
         return ([], self.parameters.data)
     
-    def summary(self, file = sys.stdout):
+    def summary(self, file=sys.stdout):
         """
         Print a summary of the model
         """
         print(self.__class__.__name__, file=file)
 
     @staticmethod
-    def check_data_format(inputs, outputs, states = None, event_states = None, t_mets = None):
+    def check_data_format(inputs, outputs, states=None, event_states=None, t_mets=None):
         if len(inputs) == 0:
             raise ValueError("No data provided. inputs must be in format [run1_inputs, ...] and have at least one element")
         if len(inputs) != len(outputs):
@@ -92,9 +92,9 @@ class DataModel(PrognosticsModel, ABC):
         Create a Data Model from an existing PrognosticsModel (i.e., a :term:`surrogate` model). Generates data through simulation with supplied load functions. Then calls :py:func:`from_data` to generate the model.
 
         Args:
-            m (PrognosticsModel): 
+            m (PrognosticsModel):
                 Model to generate data from
-            load_functions (list[function]): 
+            load_functions (list[function]):
                 Each index is a callable loading function of (t, x = None) -> z used to predict :term:`future load` at a given time (t) and :term:`state` (x)
 
         Keyword Args:
@@ -106,8 +106,8 @@ class DataModel(PrognosticsModel, ABC):
         Returns:
             DataModel: Trained PrognosticsModel
         """
-         # Configure
-        config = { # Defaults
+        # Configure
+        config = {  # Defaults
             'add_dt': True,
             'input_keys': m.inputs.copy(),
             'output_keys': m.outputs.copy(),
@@ -139,12 +139,14 @@ class DataModel(PrognosticsModel, ABC):
 
         # Create sim config for each element
         sim_cfg = [{
-            cfg : config[cfg][i]
-               for cfg in sim_cfg_params if cfg in config
+            cfg: config[cfg][i]
+            for cfg in sim_cfg_params if cfg in config
         } for i in range(len(load_functions))]
 
-        # Simulate            
-        data = [m.simulate_to_threshold(load, **sim_cfg[i]) for (i, load) in enumerate(load_functions)]
+        # Simulate
+        data = [
+            m.simulate_to_threshold(load, **sim_cfg[i])
+            for (i, load) in enumerate(load_functions)]
 
         # Prepare data
         times = [d.times for d in data]
@@ -152,14 +154,33 @@ class DataModel(PrognosticsModel, ABC):
             config['input_keys'].append('dt')
             if len(data[0].inputs) > 0 and len(data[0].inputs[0]) == 0:
                 # No inputs
-                inputs = [np.array([[config['dt'][i]] for _ in data[i].inputs], dtype=float) for i in range(len(data))]
+                inputs = [
+                    np.array(
+                        [[config['dt'][i]] for _ in data[i].inputs],
+                        dtype=float)
+                    for i in range(len(data))]
             else:
-                inputs = [np.array([np.hstack((u_i.matrix[:][0].T, [config['dt'][i]])) for u_i in d.inputs], dtype=float) for i, d in enumerate(data)]
+                inputs = [
+                    np.array(
+                        [
+                            np.hstack((u_i.matrix[:][0].T, [config['dt'][i]]))
+                            for u_i in d.inputs],
+                        dtype=float)
+                    for i, d in enumerate(data)]
         else:
             inputs = [d.inputs for d in data]
         outputs = [d.outputs for d in data]
         states = [d.states for d in data]
         event_states = [d.event_states for d in data]
-        t_met = [[list(m.threshold_met(x).values()) for x in state] for state in states]
+        t_met = [
+            [list(m.threshold_met(x).values()) for x in state]
+            for state in states]
 
-        return cls.from_data(times = times, inputs = inputs, states = states, outputs = outputs, event_states = event_states, t_met= t_met, **config)
+        return cls.from_data(
+            times=times,
+            inputs=inputs,
+            states=states,
+            outputs=outputs,
+            event_states=event_states,
+            t_met=t_met,
+            **config)

--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -7,10 +7,11 @@ from scipy.interpolate import interp1d
 import types
 from warnings import warn
 
-from ..exceptions import ProgModelInputException
-from ..sim_result import SimResult, LazySimResult
-from .. import LinearModel, PrognosticsModel
-from . import DataModel
+from prog_models.exceptions import ProgModelInputException
+from prog_models.sim_result import SimResult, LazySimResult
+from prog_models import LinearModel, PrognosticsModel
+from prog_models.data_models import DataModel
+
 
 class DMDModel(LinearModel, DataModel):
     """
@@ -64,7 +65,7 @@ class DMDModel(LinearModel, DataModel):
         if isinstance(dmd_matrix, PrognosticsModel):
             # Keep for backwards compatability (in first version, model was passed into constructor)
             warn('Passing a PrognosticsModel into DMDModel is deprecated and will be removed in v1.5.  Please use DMDModel.from_model instead', DeprecationWarning)
-            return cls.from_model(dmd_matrix, args[0], **kwargs) 
+            return cls.from_model(dmd_matrix, args[0], **kwargs)
         return DataModel.__new__(cls)
 
     def __getnewargs__(self):
@@ -101,7 +102,7 @@ class DMDModel(LinearModel, DataModel):
         n_outputs = len(params['output_keys'])
         
         has_overwritten_threshold_eqn = hasattr(self, 'events')
-        if has_overwritten_threshold_eqn: 
+        if has_overwritten_threshold_eqn:
              # To support overridding to add custom threshold equation
             n_events = 0
         else:
@@ -111,15 +112,15 @@ class DMDModel(LinearModel, DataModel):
 
         n_total = n_states + n_outputs + n_events
 
-        self.A = dmd_matrix[:,0:n_total]
-        self.B = np.vstack(dmd_matrix[:,n_total:n_total+n_inputs]) 
-        self.C = np.zeros((n_outputs,n_total))
+        self.A = dmd_matrix[:, 0:n_total]
+        self.B = np.vstack(dmd_matrix[:, n_total:n_total+n_inputs])
+        self.C = np.zeros((n_outputs, n_total))
         for iter1 in range(n_outputs):
-            self.C[iter1,n_states+iter1] = 1 
+            self.C[iter1, n_states+iter1] = 1
         if not has_overwritten_threshold_eqn:
-            self.F = np.zeros((n_events,n_total))
+            self.F = np.zeros((n_events, n_total))
         for iter2 in range(n_events):
-            self.F[iter2,n_states+n_outputs+iter2] = 1 
+            self.F[iter2, n_states+n_outputs+iter2] = 1
 
         super().__init__(**params)
         
@@ -131,34 +132,34 @@ class DMDModel(LinearModel, DataModel):
             self.parameters['x0'] = self.StateContainer(params['x0'])
 
     @classmethod
-    def from_data(cls, times, inputs, outputs, states = None, event_states = None, **kwargs):
+    def from_data(cls, times, inputs, outputs, states=None, event_states=None, **kwargs):
         """
         Create a DMD model from data
 
         Args:
-            times (list[list]): 
+            times (list[list]):
                 list of input data for use in data. Each element is the times for a single run of size (n_times)
-            inputs (list[np.array]): 
+            inputs (list[np.array]):
                 list of :term:`input` data for use in data. Each element is the inputs for a single run of size (n_times, n_inputs)
-            outputs (list[np.array]): 
+            outputs (list[np.array]):
                 list of :term:`output` data for use in data. Each element is the outputs for a single run of size (n_times, n_outputs)
-            states (list[np.array], optional): 
+            states (list[np.array], optional):
                 list of :term:`state` data for use in data. Each element is the states for a single run of size (n_times, n_states)
-            event_states (list[np.array], optional): 
+            event_states (list[np.array], optional):
                 list of :term:`event state` data for use in data. Each element is the event states for a single run of size (n_times, n_event_states)
 
         Keyword Args:
-            trim_data_to (float, optional): 
+            trim_data_to (float, optional):
                 Fraction (0-1) of data resulting from :py:func:`prog_models.PrognosticsModel.simulate_to_threshold` used to train DMD surrogate model
                 e.g. if trim_data_to = 0.7 and the simulated data spans from t=0 to 100, the surrogate model is trained on the data from t=0 to 70 \n   
-                Note: To trim data to a set time, use the 'horizon' parameter  
+                Note: To trim data to a set time, use the 'horizon' parameter
             stability_tol (float, optional):
                 Value that determines the tolerance for DMD matrix stability
             training_noise (float, optional):
                 Noise added to the training data sampled from a standard normal distribution with standard deviation of training_noise. Adding noise to the training data results in a slight perturbation that removes any linear dependencies among the data
-            input_keys (list[str], optional): 
+            input_keys (list[str], optional):
                 List of :term:`input` keys
-            state_keys (list[str], optional): 
+            state_keys (list[str], optional):
                 List of :term:`state` keys
             output_keys (list[str], optional):
                 List of :term:`output` keys
@@ -175,20 +176,20 @@ class DMDModel(LinearModel, DataModel):
             DMDModel: Model generated from data
         """
         # Configure
-        config = { # Defaults
+        config = {  # Defaults
             'trim_data_to': 1,
             'stability_tol': 1e-05,
             'training_noise': 1e-05,
             'input_keys': None,
             'state_keys': None,
             'output_keys': None,
-            'event_keys': None, 
+            'event_keys': None,
             'dt': None
         }
         config.update(kwargs)
 
         # Input validation
-        if not isinstance(config['trim_data_to'], Number) or config['trim_data_to']>1 or config['trim_data_to']<=0:
+        if not isinstance(config['trim_data_to'], Number) or config['trim_data_to'] > 1 or config['trim_data_to'] <= 0:
             raise ProgModelInputException("Invalid 'trim_data_to' input value, must be between 0 and 1.")
         if not isinstance(config['stability_tol'], Number) or  config['stability_tol'] < 0:
             raise ProgModelInputException(f"Invalid 'stability_tol' input value {config['stability_tol']}, must be a positive number.")
@@ -257,7 +258,7 @@ class DMDModel(LinearModel, DataModel):
 
         for input_key in config['input_keys']:
             if input_key in config['output_keys'] or input_key in config['event_keys']:
-                warn(f"Input value '{input_key}' is duplicated in outputs or events")     
+                warn(f"Input value '{input_key}' is duplicated in outputs or events")
 
         for output_key in config['output_keys']:
             if output_key in config['event_keys']:
@@ -287,12 +288,12 @@ class DMDModel(LinearModel, DataModel):
 
             if isinstance(u, SimResult):
                 u = u.to_numpy(config['input_keys'])
-            
+
             if states != None:
                 x = states[run]
                 if len(x) != len(u):
                     raise ProgModelInputException(f"Must have same number of steps for inputs, states, and outputs in a single run. Not true for states in run {run}")
-                if isinstance(x, SimResult):     
+                if isinstance(x, SimResult):
                     x = x.to_numpy(config['state_keys'])
             else:
                 x = np.array([[] for _ in u])
@@ -304,7 +305,7 @@ class DMDModel(LinearModel, DataModel):
                 es = event_states[run]
                 if len(es) != len(u):
                     raise ProgModelInputException(f"Must have same number of steps for inputs, event_states, and outputs in a single run. Not true for event_states in run {run}")
-                if isinstance(es, SimResult):    
+                if isinstance(es, SimResult):
                     es = es.to_numpy(config['event_keys'])
             else:
                 es = np.array([[] for _ in u])
@@ -316,11 +317,11 @@ class DMDModel(LinearModel, DataModel):
                 u = u[:index]
                 x = x[:index]
                 z = z[:index]
-                es = es[:index]       
+                es = es[:index]
             
             # Interpolate
             # This is done when dt and save_freq are not equal. 
-            # dt is the frequency at which simulation is performed to generate data, 
+            # dt is the frequency at which simulation is performed to generate data,
             # while save_freq is the frequency for the dmd_matrix
             if config['save_freq'] != config['dt'] or config['dt'] is None:
                 if isinstance(config['save_freq'], (tuple, list, np.ndarray)):
@@ -339,7 +340,7 @@ class DMDModel(LinearModel, DataModel):
                 if n_states != 0:
                     x = interp1d(t, x, axis=0)(t_new)
                 z = interp1d(t, z, axis=0)(t_new)
-                if n_events != 0:  
+                if n_events != 0:
                     # Optimization - avoid interpolation of empty array
                     es = interp1d(t, es, axis=0)(t_new)
                 t = t_new  # Reset time to new timestep
@@ -359,9 +360,9 @@ class DMDModel(LinearModel, DataModel):
             time_list.append(t)
             x_mat = np.hstack((x, z, es, u)).T
             x_list.append(x_mat[:, :-1])
-            xprime_list.append(x_mat[:-n_inputs if n_inputs != 0 else None, 1:])    
+            xprime_list.append(x_mat[:-n_inputs if n_inputs != 0 else None, 1:])
 
-        # Format training data for DMD and solve for matrix A, in the form X' = AX 
+        # Format training data for DMD and solve for matrix A, in the form X' = AX
         print('Generate DMD Surrogate Model')
 
         if 'x0' not in config:
@@ -372,22 +373,22 @@ class DMDModel(LinearModel, DataModel):
         xprime_mat = np.hstack((xprime_list[:]))
 
         # Calculate DMD matrix using the Moore-Penrose pseudo-inverse:
-        dmd_matrix = np.dot(xprime_mat,np.linalg.pinv(x_mat))        
+        dmd_matrix = np.dot(xprime_mat, np.linalg.pinv(x_mat))
 
         # Check for stability of dmd_matrix
-        eig_val, _ = np.linalg.eig(dmd_matrix[:,0:-n_inputs if n_inputs > 0 else None])            
+        eig_val, _ = np.linalg.eig(dmd_matrix[:, 0:-n_inputs if n_inputs > 0 else None])
         
-        if sum(eig_val>1) != 0:
+        if sum(eig_val > 1) != 0:
             for eig_val_i in eig_val:
-                if eig_val_i>1 and eig_val_i-1>config['stability_tol']:
+                if eig_val_i > 1 and (eig_val_i-1) > config['stability_tol']:
                     warn("The DMD matrix is unstable, may result in poor approximation.")
 
         del config['dt']
 
         # Build Model
         return cls(
-            dmd_matrix, 
-            dt = config['save_freq'], 
+            dmd_matrix,
+            dt=config['save_freq'],
             **config)
         
     @classmethod
@@ -415,27 +416,27 @@ class DMDModel(LinearModel, DataModel):
 
         return m_dmd
 
-    def next_state(self, x, u, _):   
+    def next_state(self, x, u, _):
         x.matrix = np.matmul(self.A, x.matrix) + self.E
         if self.B.shape[1] != 0:
            x.matrix += np.matmul(self.B, u.matrix)
         
         return x   
 
-    def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs):
-        # Save keyword arguments same as DMD training for approximation 
+    def simulate_to_threshold(self, future_loading_eqn, first_output=None, threshold_keys=None, **kwargs):
+        # Save keyword arguments same as DMD training for approximation
         kwargs_sim = kwargs.copy()
         kwargs_sim['save_freq'] = self.dt
         kwargs_sim['dt'] = self.dt
 
         # Simulate to threshold at DMD time step
-        results = super().simulate_to_threshold(future_loading_eqn,first_output, threshold_keys, **kwargs_sim)
+        results = super().simulate_to_threshold(future_loading_eqn, first_output, threshold_keys, **kwargs_sim)
         
         # Interpolate results to be at user-desired time step
         if 'dt' in kwargs:
             warn("dt is not used in DMD approximation")
 
-        # Default parameters 
+        # Default parameters
         config = {
             'dt': None,
             'save_freq': None,
@@ -454,7 +455,7 @@ class DMDModel(LinearModel, DataModel):
         # In this case, the user wants something different than what the DMD approximation retuns, so we must interpolate 
         # Define time vector based on user specifications
         time_basic = [results.times[0], results.times[-1]]
-        time_basic.extend(config['save_pts'])                       
+        time_basic.extend(config['save_pts'])
         if config['save_freq'] != None:
             if isinstance(config['save_freq'], tuple):
                 # Tuple used to specify start and frequency
@@ -462,9 +463,9 @@ class DMDModel(LinearModel, DataModel):
                 # Use starting time or the next multiple
                 t_start = config['save_freq'][0]
                 start = max(t_start, results.times[0] - (results.times[0]-t_start)%t_step)
-                time_array = np.arange(start+t_step,results.times[-1],t_step)
+                time_array = np.arange(start+t_step, results.times[-1],t_step)
             else: 
-                time_array = np.arange(results.times[0]+config['save_freq'],results.times[-1],config['save_freq'])
+                time_array = np.arange(results.times[0]+config['save_freq'], results.times[-1], config['save_freq'])
             time_basic.extend(time_array.tolist())
         time_interp = sorted(time_basic)
 

--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -396,7 +396,7 @@ class DMDModel(LinearModel, DataModel):
         process_noise_temp = {key: 0 for key in m.events}
         config = {
             'add_dt': False,
-            'process_noise': {**m.parameters['process_noise'],**m.parameters['measurement_noise'],**process_noise_temp},
+            'process_noise': {**m.parameters['process_noise'], **m.parameters['measurement_noise'], **process_noise_temp},
             'measurement_noise': m.parameters['measurement_noise'],
             'process_noise_dist': m.parameters.get('process_noise_dist', 'normal'),
             'measurement_noise_dist': m.parameters.get('measurement_noise_dist', 'normal')
@@ -446,25 +446,26 @@ class DMDModel(LinearModel, DataModel):
 
         if (config['save_freq'] == self.dt or
             (isinstance(config['save_freq'], tuple) and
-                config['save_freq'][0]%self.dt < 1e-9 and
+                config['save_freq'][0] % self.dt < 1e-9 and
                 config['save_freq'][1] == self.dt)
             ) and config['save_pts'] == []:
-            # In this case, the user wants what the DMD approximation returns 
-            return results 
+            # In this case, the user wants what the DMD approximation returns
+            return results
 
-        # In this case, the user wants something different than what the DMD approximation retuns, so we must interpolate 
+        # In this case, the user wants something different than what the DMD 
+        # approximation retuns, so we must interpolate.
         # Define time vector based on user specifications
         time_basic = [results.times[0], results.times[-1]]
         time_basic.extend(config['save_pts'])
-        if config['save_freq'] != None:
+        if config['save_freq'] is not None:
             if isinstance(config['save_freq'], tuple):
                 # Tuple used to specify start and frequency
                 t_step = config['save_freq'][1]
                 # Use starting time or the next multiple
                 t_start = config['save_freq'][0]
-                start = max(t_start, results.times[0] - (results.times[0]-t_start)%t_step)
-                time_array = np.arange(start+t_step, results.times[-1],t_step)
-            else: 
+                start = max(t_start, results.times[0] - (results.times[0]-t_start) % t_step)
+                time_array = np.arange(start+t_step, results.times[-1], t_step)
+            else:
                 time_array = np.arange(results.times[0]+config['save_freq'], results.times[-1], config['save_freq'])
             time_basic.extend(time_array.tolist())
         time_interp = sorted(time_basic)
@@ -473,7 +474,7 @@ class DMDModel(LinearModel, DataModel):
         states_dict_temp = {}
         for states_name in self.states:
             states_list_temp = [results.states[iter1a][states_name] for iter1a in range(len(results.states))]
-            states_dict_temp[states_name] = interp1d(results.times,states_list_temp)(time_interp)
+            states_dict_temp[states_name] = interp1d(results.times, states_list_temp)(time_interp)
         states_interp = [
             self.StateContainer({key: state[i] for key, state in states_dict_temp.items()})
             for i in range(len(time_interp))
@@ -483,13 +484,13 @@ class DMDModel(LinearModel, DataModel):
         inputs_dict_temp = {}
         for inputs_name in self.inputs:
             inputs_list_temp = [results.inputs[iter1a][inputs_name] for iter1a in range(len(results.inputs))]
-            inputs_dict_temp[inputs_name] = interp1d(results.times,inputs_list_temp)(time_interp)
+            inputs_dict_temp[inputs_name] = interp1d(results.times, inputs_list_temp)(time_interp)
         inputs_interp = [
             self.InputContainer({key: input[i] for key, input in inputs_dict_temp.items()}) for i in range(len(time_interp))
         ]
 
-        states = SimResult(time_interp,states_interp)
-        inputs = SimResult(time_interp,inputs_interp)
+        states = SimResult(time_interp, states_interp)
+        inputs = SimResult(time_interp, inputs_interp)
         outputs = LazySimResult(self.output, time_interp, states_interp)
         event_states = LazySimResult(self.event_state, time_interp, states_interp)
 

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -7,7 +7,6 @@ from numbers import Number
 import numpy as np
 import sys
 from tensorflow import keras
-from tensorflow.keras import layers
 from warnings import warn
 
 from prog_models.data_models import DataModel
@@ -209,7 +208,7 @@ class LSTMStateTransitionModel(DataModel):
         print("Window_size: ", self.parameters['window'], file=file)
         if self.parameters['state_model'] is not None:
             print('\nState Model: ', file=file)
-            self.parameters['state_model'].summary(print_fn= file.write, expand_nested=expand_nested, show_trainable=show_trainable)
+            self.parameters['state_model'].summary(print_fn=file.write, expand_nested=expand_nested, show_trainable=show_trainable)
         
         print('\nOutput Model: ', file=file)
         self.parameters['output_model'].summary(print_fn=file.write, expand_nested=expand_nested, show_trainable=show_trainable)
@@ -269,9 +268,9 @@ class LSTMStateTransitionModel(DataModel):
                     u_i = [[[u[i+j]] for j in range(1, window+1)] for i in range(len(u)-window)]
                 elif isinstance(u[0], (list, np.ndarray)):
                     # Input is d-d array
-                    # Note: 1 is added to account for current time (current input used to predict output at time i) 
+                    # Note: 1 is added to account for current time (current input used to predict output at time i)
                     n_inputs = len(u[0])
-                    u_i = [[[u[i+j][k] for k in range(n_inputs)] for j in range(1,window+1)] for i in range(len(u)-window)]
+                    u_i = [[[u[i+j][k] for k in range(n_inputs)] for j in range(1, window+1)] for i in range(len(u)-window)]
                 else:
                     raise TypeError(f"Unsupported input type: {type(u)} for internal element (data[0][i]")  
             else:
@@ -285,11 +284,12 @@ class LSTMStateTransitionModel(DataModel):
                     # No outputs
                     z = []
                 else:
-                    z = np.array([z_i.matrix[:,0] for z_i in z])
+                    z = np.array([z_i.matrix[:, 0] for z_i in z])
 
             if isinstance(z, (list, np.ndarray)):
                 if len(z) != len(u) and len(u) != 0 and len(z) != 0:
-                    # Checked here to avoid SimResults from accidentially triggering this check
+                    # Checked here to avoid SimResults from accidentially
+                    # triggering this check
                     raise IndexError(f"Number of outputs ({len(z)}) does not match number of inputs ({len(u)})")
 
                 if len(z) == 0:
@@ -303,7 +303,7 @@ class LSTMStateTransitionModel(DataModel):
                     n_outputs = len(z[0])
                     z_i = [[z[i][k] for k in range(n_outputs)] for i in range(window, len(z))]
                 else:
-                    raise TypeError(f"Unsupported input type: {type(z)} for internal element (output[i])")  
+                    raise TypeError(f"Unsupported input type: {type(z)} for internal element (output[i])")
 
                 # Also add to input (past outputs are part of input)
                 z_ii = [[z[i+j] for j in range(window)] for i in range(len(z_i))]
@@ -328,7 +328,8 @@ class LSTMStateTransitionModel(DataModel):
 
                 if isinstance(es, (list, np.ndarray)):
                     if len(es) != len(u) and len(u) != 0 and len(es) != 0:
-                        # Checked here to avoid SimResults from accidentially triggering this check
+                        # Checked here to avoid SimResults from accidentially
+                        # triggering this check
                         raise IndexError(f"Number of event_states ({len(es)}) does not match number of inputs ({len(u)})")
 
                     if len(es) == 0:
@@ -342,7 +343,7 @@ class LSTMStateTransitionModel(DataModel):
                         n_events = len(es[0])
                         es_i = [[es[i][k] for k in range(n_events)] for i in range(window, len(es))]
                     else:
-                        raise TypeError(f"Unsupported input type: {type(es)} for internal element (es[i])")  
+                        raise TypeError(f"Unsupported input type: {type(es)} for internal element (es[i])")
 
                 else:
                     raise TypeError(f"Unsupported data type: {type(es)}. event state must be in format List[Tuple[np.array, np.array]] or List[Tuple[SimResult, SimResult]]")
@@ -360,7 +361,8 @@ class LSTMStateTransitionModel(DataModel):
 
                 if isinstance(t, (list, np.ndarray)):
                     if len(t) != len(u) and len(u) != 0 and len(t) != 0:
-                        # Checked here to avoid SimResults from accidentially triggering this check
+                        # Checked here to avoid SimResults from accidentially
+                        # triggering this check
                         raise IndexError(f"Number of t_met ({len(t)}) does not match number of inputs ({len(u)})")
 
                     if len(t) == 0:
@@ -506,13 +508,13 @@ class LSTMStateTransitionModel(DataModel):
             raise TypeError(f"normalize must be a boolean, not {type(params['normalize'])}")
 
         # Prepare datasets
-        (u_all, z_all, es_all, t_all) = LSTMStateTransitionModel.pre_process_data(inputs, outputs, event_states = event_states, t_met = t_met, **params)
+        (u_all, z_all, es_all, t_all) = LSTMStateTransitionModel.pre_process_data(inputs, outputs, event_states=event_states, t_met=t_met, **params)
 
         # Normalize
         if params['normalize']:
             n_inputs = len(inputs[0][0])
-            u_mean = np.mean(u_all[:,0,:n_inputs], axis=0)
-            u_std = np.std(u_all[:,0,:n_inputs], axis=0)
+            u_mean = np.mean(u_all[:, 0, :n_inputs], axis=0)
+            u_std = np.std(u_all[:, 0, :n_inputs], axis=0)
             # If there's no variation- don't normalize 
             u_std[u_std == 0] = 1
             z_mean = np.mean(z_all, axis=0)
@@ -577,7 +579,14 @@ class LSTMStateTransitionModel(DataModel):
         model.compile(optimizer="rmsprop", loss="mse", metrics=["mae"])
         
         # Train model
-        history = model.fit(u_all, output_data, epochs=params['epochs'], callbacks = callbacks, validation_split = params['validation_split'], workers = params['workers'],  use_multiprocessing = params['workers'] > 1)
+        history = model.fit(
+            u_all,
+            output_data,
+            epochs=params['epochs'],
+            callbacks=callbacks,
+            validation_split=params['validation_split'],
+            workers=params['workers'],
+            use_multiprocessing=(params['workers'] > 1))
 
         model = keras.models.load_model("best_model.keras")
 
@@ -605,7 +614,7 @@ class LSTMStateTransitionModel(DataModel):
 
         return cls(output_model, state_model, event_state_model, t_met_model, history = history, **params)
         
-    def simulate_to_threshold(self, future_loading_eqn, first_output = None, threshold_keys = None, **kwargs):
+    def simulate_to_threshold(self, future_loading_eqn, first_output=None, threshold_keys=None, **kwargs):
         t = kwargs.get('t0', 0)
         dt = kwargs.get('dt', 0.1)
         x = kwargs.get('x', self.initialize(future_loading_eqn(t), first_output))
@@ -682,7 +691,7 @@ class LSTMStateTransitionModel(DataModel):
                 plt.figure(plts[list(metrics).index(key[4:])].number)
             else:
                 plts.append(plt.figure())
-            plt.plot(self.history.history[key], label = key)
+            plt.plot(self.history.history[key], label=key)
             plt.xlabel('epochs')
             plt.ylabel(key)
             plt.legend()

--- a/src/prog_models/data_models/pce.py
+++ b/src/prog_models/data_models/pce.py
@@ -58,7 +58,7 @@ class PolynomialChaosExpansion(DataModel):
         Args:
             times (list[float]):
                 list of times data for use in data. Each element is the time such that inputs[i] is the inputs at time[i]
-            inputs (np.array): 
+            inputs (np.array):
                 list of :term:`input` data for use in data. Each  eelement is the inputs for a single run of size (n_samples, n_inputs*n_times)
             time_of_event (np.array):
                 Array of time of event data for use in data. Each element is the time of event for a single run of size (n_samples, n_events)
@@ -152,17 +152,18 @@ class PolynomialChaosExpansion(DataModel):
         # As a workaround we create a new UserDistribution for each timepoint for each input
         # The UserDistribution is functionally the same as the original distribution
         input_dists = [cp.UserDistribution(
-                            cdf = input_dists[key].cdf,
-                            pdf = input_dists[key].pdf,
-                            ppf = input_dists[key].ppf
-                        )
-                        for key in m.inputs
-                        for _ in range(len(times))
-                        ]
+                cdf=input_dists[key].cdf,
+                pdf=input_dists[key].pdf,
+                ppf=input_dists[key].ppf
+            )
+            for key in m.inputs
+            for _ in range(len(times))
+            ]
         J = cp.J(*input_dists)  # Joint distribution to sample from
         
         # Simulate to collect time_of_event data
         time_of_event = np.empty((params['N'], len(m.events)), dtype=np.float64)
+
         def future_loading(t, x=None):
             nonlocal interpolator
             return m.InputContainer(interpolator(t)[np.newaxis].T)
@@ -182,6 +183,11 @@ class PolynomialChaosExpansion(DataModel):
         params['input_keys'] = m.inputs
         params['x'] = x
         params['times'] = times
-        return cls.from_data(inputs=all_samples.T, time_of_event=time_of_event, event_keys=m.events, J=J, **params)
+        return cls.from_data(
+            inputs=all_samples.T,
+            time_of_event=time_of_event,
+            event_keys=m.events,
+            J=J,
+            **params)
 
 PCE = PolynomialChaosExpansion

--- a/src/prog_models/data_models/pce.py
+++ b/src/prog_models/data_models/pce.py
@@ -104,12 +104,12 @@ class PolynomialChaosExpansion(DataModel):
 
         # Train
         inputs = inputs.T
-        expansion = cp.generate_expansion(order=params['order'], dist=params['J']) # Order=2 is the only hyperparameter
+        expansion = cp.generate_expansion(order=params['order'], dist=params['J'])  # Order=2 is the only hyperparameter
         surrogates = [
             cp.fit_regression(expansion, inputs, toe_i) for toe_i in time_of_event.T
         ]
 
-        return cls(surrogates, times = times, input_keys = input_keys, **params)
+        return cls(surrogates, times=times, input_keys=input_keys, **params)
 
     @classmethod
     def from_model(cls, m, x, input_dists, times, **kwargs):
@@ -135,8 +135,8 @@ class PolynomialChaosExpansion(DataModel):
                 Order of the polynomial chaos expansion
         """
         default_params = {
-            'N': 1000, 
-            'dt': 0.1, 
+            'N': 1000,
+            'dt': 0.1,
         }
         params = default_params.copy()
         params.update(kwargs)
@@ -156,7 +156,7 @@ class PolynomialChaosExpansion(DataModel):
                             pdf = input_dists[key].pdf,
                             ppf = input_dists[key].ppf
                         )
-                        for key in m.inputs 
+                        for key in m.inputs
                         for _ in range(len(times))
                         ]
         J = cp.J(*input_dists)  # Joint distribution to sample from
@@ -171,7 +171,7 @@ class PolynomialChaosExpansion(DataModel):
         for i in range(params['N']):
             # Sample
             inputs = np.reshape(all_samples[:, i], (len(m.inputs), len(times)))
-            interpolator = sp.interpolate.interp1d(times, inputs, bounds_error = False, fill_value = inputs[:, -1])
+            interpolator = sp.interpolate.interp1d(times, inputs, bounds_error=False, fill_value=inputs[:, -1])
 
             # Simulate to get data
             time_of_event_i = m.time_of_event(x, future_loading, dt=params['dt'])
@@ -182,6 +182,6 @@ class PolynomialChaosExpansion(DataModel):
         params['input_keys'] = m.inputs
         params['x'] = x
         params['times'] = times
-        return cls.from_data(inputs = all_samples.T, time_of_event = time_of_event, event_keys = m.events, J=J, **params)
+        return cls.from_data(inputs=all_samples.T, time_of_event=time_of_event, event_keys=m.events, J=J, **params)
 
 PCE = PolynomialChaosExpansion

--- a/src/prog_models/datasets/nasa_battery.py
+++ b/src/prog_models/datasets/nasa_battery.py
@@ -42,7 +42,7 @@ urls = {
 cache = {}  # Cache for downloaded data
 # Cache is used to prevent files from being downloaded twice
 
-def load_data(batt_id : str) -> tuple:
+def load_data(batt_id: str) -> tuple:
     """
     .. versionadded:: 1.3.0
 
@@ -77,7 +77,7 @@ def load_data(batt_id : str) -> tuple:
         # Download data
         try:
             response = requests.get(url, allow_redirects=True)
-        except requests.exceptions.RequestException as e: # handle chain of errors
+        except requests.exceptions.RequestException:  # handle chain of errors
             raise ConnectionRefusedError("Data download failed. This may be because of issues with your internet connection or the datasets may have moved. Please check your internet connection and make sure you're using the latest version of prog_models. If the problem persists, please submit an issue on the prog_models issue page (https://github.com/nasa/prog_models/issues) for further investigation.")
 
         # Unzip response
@@ -94,19 +94,19 @@ def load_data(batt_id : str) -> tuple:
 
     # Reformat
     desc = {
-        'procedure': str(result['procedure'][0,0][0]),
-        'description': str(result['description'][0,0][0]),
-        'runs': 
+        'procedure': str(result['procedure'][0, 0][0]),
+        'description': str(result['description'][0, 0][0]),
+        'runs':
         [
             {
-                'type': str(run_type[0]), 
+                'type': str(run_type[0]),
                 'desc': str(desc[0]),
                 'date': str(date[0])
-            } for (run_type, desc, date) in zip(result['step'][0,0]['type'][0], result['step'][0,0]['comment'][0], result['step'][0,0]['date'][0])
+            } for (run_type, desc, date) in zip(result['step'][0, 0]['type'][0], result['step'][0, 0]['comment'][0], result['step'][0,0]['date'][0])
         ]
     }
 
-    result = result['step'][0,0]
+    result = result['step'][0, 0]
     result = [
         pd.DataFrame(np.array([
             result[key][0, i][0] for key in ('relativeTime', 'current', 'voltage', 'temperature')

--- a/src/prog_models/datasets/nasa_battery.py
+++ b/src/prog_models/datasets/nasa_battery.py
@@ -108,9 +108,12 @@ def load_data(batt_id: str) -> tuple:
 
     result = result['step'][0, 0]
     result = [
-        pd.DataFrame(np.array([
-            result[key][0, i][0] for key in ('relativeTime', 'current', 'voltage', 'temperature')
-        ], np.float64).T, columns = ('relativeTime', 'current', 'voltage', 'temperature')) for i in range(result.shape[1])
+        pd.DataFrame(
+            np.array([
+                result[key][0, i][0] for key in ('relativeTime', 'current', 'voltage', 'temperature')
+            ], np.float64).T,
+            columns=('relativeTime', 'current', 'voltage', 'temperature')
+        ) for i in range(result.shape[1])
     ]
     for r in result:
         r.set_index('relativeTime')

--- a/src/prog_models/datasets/nasa_cmapss.py
+++ b/src/prog_models/datasets/nasa_cmapss.py
@@ -10,7 +10,7 @@ cache = None
 URL = "https://data.nasa.gov/download/ff5v-kuh6/application%2Fzip"
 
 
-def load_data(dataset_id : int) -> tuple:
+def load_data(dataset_id: int) -> tuple:
     """
     .. versionadded:: 1.3.0
     
@@ -103,7 +103,7 @@ def load_data(dataset_id : int) -> tuple:
     with cache.open(f'train_{dataset_id}.txt', mode='r') as f:
         with io.BufferedReader(f) as f2:
             train = np.loadtxt(f2)
-            train = pd.DataFrame(train, columns=['unit', 'cycle', 'setting1', 'setting2', 'setting3'] + [f'sensor{i}' for i in range(1,22)])
+            train = pd.DataFrame(train, columns=['unit', 'cycle', 'setting1', 'setting2', 'setting3'] + [f'sensor{i}' for i in range(1, 22)])
 
     with cache.open(f'RUL_{dataset_id}.txt', mode='r') as f:
         with io.BufferedReader(f) as f2:

--- a/src/prog_models/ensemble_model.py
+++ b/src/prog_models/ensemble_model.py
@@ -101,7 +101,7 @@ class EnsembleModel(PrognosticsModel):
 
         return self.OutputContainer(zs_final)
         
-    def event_state(self, x):
+    def event_state(self, x) -> dict:
         es = [m.event_state(m.StateContainer(x)) for m in self.parameters['models']]
         es_final = {}
         for es_i in es:

--- a/src/prog_models/ensemble_model.py
+++ b/src/prog_models/ensemble_model.py
@@ -15,7 +15,7 @@ class EnsembleModel(PrognosticsModel):
         :language: python
         :class: highlight
     
-    Ensembe Models are constructed from a set of other models (e.g., :python:`m = EnsembleModel((m1, m2, m3))`). The models then operate functionally as one prognostic model. 
+    Ensembe Models are constructed from a set of other models (e.g., :python:`m = EnsembleModel((m1, m2, m3))`). The models then operate functionally as one prognostic model.
 
     See example :download:`examples.ensemble <../../../../prog_models/examples/ensemble.py>`
 

--- a/src/prog_models/linear_model.py
+++ b/src/prog_models/linear_model.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from prog_models import PrognosticsModel
 
+
 class LinearModel(PrognosticsModel, ABC):
     """
     A linear prognostics :term:`model`. Used when behavior can be described using a simple linear time-series model defined by the following equations:

--- a/src/prog_models/linear_model.py
+++ b/src/prog_models/linear_model.py
@@ -96,9 +96,9 @@ class LinearModel(PrognosticsModel, ABC):
                             ["C", "outputs", "states"])
         self._propertyCheck(self.n_outputs, 1,
                             ["D", "outputs", "1"])
-        self._propertyCheck(self.n_states, 1, 
+        self._propertyCheck(self.n_states, 1,
                             ["E", "states", "1"])
-        self._propertyCheck(self.n_events, 1, 
+        self._propertyCheck(self.n_events, 1,
                             ["G", "events", "1"])
 
         if self.F is not None:

--- a/src/prog_models/loading.py
+++ b/src/prog_models/loading.py
@@ -44,7 +44,7 @@ class MovingAverage():
             self.values[key][self.index] = value
         self.index = (self.index + 1) % self.window
 
-    def __call__(self, t, x = None):
+    def __call__(self, t, x=None):
         """
         Return the average of the values in the window
 
@@ -80,7 +80,7 @@ class GuassianNoiseLoadWrapper():
         self.fcn = fcn
         self.std = std
 
-    def __call__(self, t, x = None):
+    def __call__(self, t, x=None):
         """
         Return the load with noise added
 

--- a/src/prog_models/loading.py
+++ b/src/prog_models/loading.py
@@ -25,7 +25,7 @@ class MovingAverage():
     >>>     future_load.add_load(load)
     >>> m.simulate_to_threshold(future_load)
     """
-    def __init__(self, InputContainer, window = 10):
+    def __init__(self, InputContainer, window=10):
         self.window = window
         self.InputContainer = InputContainer
         self.values = {}

--- a/src/prog_models/models/battery_electrochem.py
+++ b/src/prog_models/models/battery_electrochem.py
@@ -95,7 +95,7 @@ def update_qnSBmax(params: dict) -> dict:
     }
 
 def update_v0(params: dict) -> dict:
-    # update the initial voltage 
+    # update the initial voltage
 
     if 'qnS' not in params['x0']:
         # qnS not yet set
@@ -640,7 +640,7 @@ class BatteryElectroChemEOL(PrognosticsModel):
         'qMax': (0, np.inf)
     }
 
-    def dx(self, _, u : dict):
+    def dx(self, _, u: dict):
         params = self.parameters
 
         return self.StateContainer(np.array([
@@ -649,17 +649,17 @@ class BatteryElectroChemEOL(PrognosticsModel):
             np.atleast_1d(params['wd'] * abs(u['i']))
         ]))
 
-    def event_state(self, x : dict) -> dict:
+    def event_state(self, x: dict) -> dict:
         e_state = (x['qMax']-self.parameters['qMaxThreshold'])/(self.parameters['x0']['qMax']-self.parameters['qMaxThreshold'])
         return {'InsufficientCapacity': max(min(e_state, 1.0), 0.0)}
 
-    def threshold_met(self, x : dict) -> dict:
+    def threshold_met(self, x: dict) -> dict:
         return {'InsufficientCapacity': x['qMax'] < self.parameters['qMaxThreshold']}
 
     def output(self, _):
         return self.OutputContainer(np.array([]))
 
-def merge_dicts(a : dict, b : dict) -> None:
+def merge_dicts(a: dict, b: dict) -> None:
     """Merge dict b into a"""
     for key in b:
         if key in a and isinstance(a[key], dict) and isinstance(b[key], dict):
@@ -729,7 +729,7 @@ class BatteryElectroChemEODEOL(BatteryElectroChemEOL, BatteryElectroChemEOD):
         self.param_callbacks['Ro'] = [OverwrittenWarning]
         super().__init__(**kwargs)
 
-    def dx(self, x : dict, u : dict):
+    def dx(self, x: dict, u: dict):
         # Set EOD Parameters (corresponding to health)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -743,18 +743,18 @@ class BatteryElectroChemEODEOL(BatteryElectroChemEOL, BatteryElectroChemEOD):
         x_dot.matrix = np.vstack((x_dot.matrix, x_dot2.matrix))
         return x_dot
 
-    def output(self, x : dict) -> dict:
+    def output(self, x: dict) -> dict:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.parameters['qMobile'] = x['qMax']
         return BatteryElectroChemEOD.output(self, x)
 
-    def event_state(self, x : dict) -> dict:
+    def event_state(self, x: dict) -> dict:
         e_state = BatteryElectroChemEOD.event_state(self, x)
         e_state.update(BatteryElectroChemEOL.event_state(self, x))
         return e_state
 
-    def threshold_met(self, x : dict) -> dict:
+    def threshold_met(self, x: dict) -> dict:
         t_met = BatteryElectroChemEOD.threshold_met(self, x)
         t_met.update(BatteryElectroChemEOL.threshold_met(self, x))
         return t_met

--- a/src/prog_models/models/dcmotor.py
+++ b/src/prog_models/models/dcmotor.py
@@ -105,7 +105,7 @@ class DCMotor(PrognosticsModel):
     ------------
         process_noise : Optional, float or dict[str, float]
           :term:`Process noise<process noise>` (applied at dx/next_state). 
-          Can be number (e.g., .2) applied to every state, a dictionary of values for each 
+          Can be number (e.g., .2) applied to every state, a dictionary of values for each
           state (e.g., {'x1': 0.2, 'x2': 0.3}), or a function (x) -> x
         process_noise_dist : Optional, str
           distribution for :term:`process noise` (e.g., normal, uniform, triangular)

--- a/src/prog_models/models/dcmotor_singlephase.py
+++ b/src/prog_models/models/dcmotor_singlephase.py
@@ -88,8 +88,8 @@ class DCMotorSP(PrognosticsModel):
     Keyword Args
     ------------
         process_noise : Optional, float or dict[str, float]
-            :term:`Process noise<process noise>` (applied at dx/next_state). 
-            Can be number (e.g., .2) applied to every state, a dictionary of values for each 
+            :term:`Process noise<process noise>` (applied at dx/next_state).
+            Can be number (e.g., .2) applied to every state, a dictionary of values for each
             state (e.g., {'x1': 0.2, 'x2': 0.3}), or a function (x) -> x
         process_noise_dist : Optional, str
             distribution for :term:`process noise` (e.g., normal, uniform, triangular)

--- a/src/prog_models/models/esc.py
+++ b/src/prog_models/models/esc.py
@@ -59,7 +59,7 @@ class ESC(PrognosticsModel):
     ------------
         process_noise : Optional, float or dict[str, float]
           :term:`Process noise<process noise>` (applied at dx/next_state). 
-          Can be number (e.g., .2) applied to every state, a dictionary of values for each 
+          Can be number (e.g., .2) applied to every state, a dictionary of values for each
           state (e.g., {'x1': 0.2, 'x2': 0.3}), or a function (x) -> x
         process_noise_dist : Optional, str
           distribution for :term:`process noise` (e.g., normal, uniform, triangular)

--- a/src/prog_models/models/esc.py
+++ b/src/prog_models/models/esc.py
@@ -29,7 +29,7 @@ class ESC(PrognosticsModel):
 
     Simple Electronic-Speed Controller (ESC) :term:`model` for powertrain modeling.
     This model replicates the behavior of the speed controller with pulse-width modulation (PWM) and commutation matrix.
-    Duty cycle simulated with a square wave using scipy signal.square function. 
+    Duty cycle simulated with a square wave using scipy signal.square function.
 
     References: [0]_, [1]_.
 

--- a/src/prog_models/models/pneumatic_valve.py
+++ b/src/prog_models/models/pneumatic_valve.py
@@ -164,7 +164,7 @@ class PneumaticValveBase(PrognosticsModel):
     default_parameters = {  # Set to defaults
         # Environmental Parameters
         'R': 8.314,  # Universal Gas Constant
-        'g': 9.81, 
+        'g': 9.81,
         'pAtm': 101325,
 
         # Valve Parameters
@@ -185,7 +185,7 @@ class PneumaticValveBase(PrognosticsModel):
         # Supply gas params (Note: Default is nitrogen)
         'gas_mass': 28.01e-3,
         'gas_temp': 293,
-        'gas_gamma': 1.4, 
+        'gas_gamma': 1.4,
         'gas_z': 1,
         'gas_R': 296.8225633702249454,
 

--- a/src/prog_models/models/pneumatic_valve.py
+++ b/src/prog_models/models/pneumatic_valve.py
@@ -67,20 +67,20 @@ class PneumaticValveBase(PrognosticsModel):
     Keyword Args
     ------------
         process_noise : Optional, float or dict[str, float]
-          :term:`Process noise<process noise>` (applied at dx/next_state). 
-          Can be number (e.g., .2) applied to every state, a dictionary of 
-          values for each state (e.g., {'x1': 0.2, 'x2': 0.3}), 
+          :term:`Process noise<process noise>` (applied at dx/next_state).
+          Can be number (e.g., .2) applied to every state, a dictionary of
+          values for each state (e.g., {'x1': 0.2, 'x2': 0.3}),
           or a function (x) -> x
         process_noise_dist : Optional, str
           distribution for :term:`process noise` 
           e.g., normal, uniform, triangular
         measurement_noise : Optional, float or dict[str, float]
           :term:`Measurement noise<measurement noise>` (applied in output eqn).
-          Can be number (e.g., .2) applied to every output, a dictionary of 
-          values for each output (e.g., {'z1': 0.2, 'z2': 0.3}), 
+          Can be number (e.g., .2) applied to every output, a dictionary of
+          values for each output (e.g., {'z1': 0.2, 'z2': 0.3}),
           or a function (z) -> z
         measurement_noise_dist : Optional, str
-           distribution for :term:`measurement noise` 
+           distribution for :term:`measurement noise`
            e.g., normal, uniform, triangular
         g : float
             Acceleration due to gravity (m/s^2)
@@ -379,7 +379,7 @@ class PneumaticValveWithWear(PneumaticValveBase):
     This class implements a Pneumatic Valve model as described in the following paper:
     `M. Daigle and K. Goebel, "A Model-based Prognostics Approach Applied to Pneumatic Valves," International Journal of Prognostics and Health Management, vol. 2, no. 2, August 2011. https://www.phmsociety.org/node/602`
 
-    :term:`Events<event>`: (4) 
+    :term:`Events<event>`: (4)
         See PneumaticValveBase
 
     :term:`Inputs/Loading<input>`: (5)

--- a/src/prog_models/models/powertrain.py
+++ b/src/prog_models/models/powertrain.py
@@ -93,7 +93,7 @@ class Powertrain(PrognosticsModel):
     }
 
     default_parameters = {
-        # Load parameters 
+        # Load parameters
         'c_q': 5.42e-7,  # coefficient of torque (APC data, derived) [dimensionless]
         'rho': 1.225,  # (Kg/m^3)
         'D': 0.381,  # (m)

--- a/src/prog_models/models/powertrain.py
+++ b/src/prog_models/models/powertrain.py
@@ -20,7 +20,7 @@ class Powertrain(PrognosticsModel):
     Parameters for a standard propeller for commercial UAV are also added to the powertrain model, so that the load torque 
     acting on the motor can be computed. At this stage, the propeller is modeled simply as a load torque proportional to the square of the rotor speed. 
     When simulating the full PWM signal, this model needs a very small time step size (e.g., dt=1e-5) to show the full dynamics.
-    Faster simulations can be achieved by ignoring the PWM square wave and acting directing on the input voltage. For example, modulating 
+    Faster simulations can be achieved by ignoring the PWM square wave and acting directing on the input voltage. For example, modulating
     the input voltage to replicate the behavior of a throttle.
 
     References:

--- a/src/prog_models/models/thrown_object.py
+++ b/src/prog_models/models/thrown_object.py
@@ -155,7 +155,7 @@ class LinearThrownObject(LinearModel):
             'impact': x['x'] <= 0
         }
 
-    def event_state(self, x): 
+    def event_state(self, x):
         x_max = x['x'] + np.square(x['v'])/(-self.parameters['g']*2) # Use speed and position to estimate maximum height
         return {
             'falling': np.maximum(x['v']/self.parameters['throwing_speed'],0),  # Throwing speed is max speed

--- a/src/prog_models/models/thrown_object.py
+++ b/src/prog_models/models/thrown_object.py
@@ -31,7 +31,7 @@ class ThrownObject(PrognosticsModel):
     ------------
         process_noise : Optional, float or dict[str, float]
           :term:`Process noise<process noise>` (applied at dx/next_state). 
-          Can be number (e.g., .2) applied to every state, a dictionary of values for each 
+          Can be number (e.g., .2) applied to every state, a dictionary of values for each
           state (e.g., {'x1': 0.2, 'x2': 0.3}), or a function (x) -> x
         process_noise_dist : Optional, str
           distribution for :term:`process noise` (e.g., normal, uniform, triangular)
@@ -58,17 +58,9 @@ class ThrownObject(PrognosticsModel):
     """
 
     inputs = []
-    states = [
-        'x',
-        'v'
-        ]
-    outputs = [
-        'x'
-    ]
-    events = [
-        'falling',
-        'impact'
-    ]
+    states = ['x', 'v']
+    outputs = ['x']
+    events = ['falling', 'impact']
 
     is_vectorized = True
 
@@ -97,7 +89,7 @@ class ThrownObject(PrognosticsModel):
             })
     
     def next_state(self, x: dict, u: dict, dt: float):
-        next_x =  x['x'] + x['v']*dt
+        next_x = x['x'] + x['v']*dt
         drag_acc = self.parameters['lumped_param'] * x['v'] * x['v']
         next_v = x['v'] + (self.parameters['g'] - drag_acc*np.sign(x['v']))*dt
         return self.StateContainer(np.array([
@@ -125,7 +117,7 @@ class ThrownObject(PrognosticsModel):
         }
 
 class LinearThrownObject(LinearModel):
-    inputs = [] 
+    inputs = []
     states = ['x', 'v']
     outputs = ['x']
     events = ['impact']
@@ -134,7 +126,7 @@ class LinearThrownObject(LinearModel):
     D = np.array([[1]])
     E = np.array([[0], [-9.81]])
     C = np.array([[1, 0]])
-    F = None # Will override method
+    F = None  # Will override method
     
 
     default_parameters = {
@@ -156,8 +148,8 @@ class LinearThrownObject(LinearModel):
         }
 
     def event_state(self, x):
-        x_max = x['x'] + np.square(x['v'])/(-self.parameters['g']*2) # Use speed and position to estimate maximum height
+        x_max = x['x'] + np.square(x['v'])/(-self.parameters['g']*2)  # Use speed and position to estimate maximum height
         return {
-            'falling': np.maximum(x['v']/self.parameters['throwing_speed'],0),  # Throwing speed is max speed
-            'impact': np.maximum(x['x']/x_max,0) if x['v'] < 0 else 1  # 1 until falling begins, then it's fraction of height
+            'falling': np.maximum(x['v']/self.parameters['throwing_speed'], 0),  # Throwing speed is max speed
+            'impact': np.maximum(x['x']/x_max, 0) if x['v'] < 0 else 1  # 1 until falling begins, then it's fraction of height
         }

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -51,7 +51,7 @@ class PrognosticsModel(ABC):
 
     Raises
     ------
-        ProgModelTypeError, ProgModelInputException, ProgModelException 
+        ProgModelTypeError, ProgModelInputException, ProgModelException
 
     Example
     -------
@@ -362,7 +362,6 @@ class PrognosticsModel(ABC):
         ----
         A model should overwrite either `next_state` or `dx`. Override `dx` for continuous models, and `next_state` for discrete, where the behavior cannot be described by the first derivative
         """
-        # Note: Default is to use the dx method (continuous model) - overwrite next_state for continuous
         dx = self.dx(x, u)
         return self.StateContainer({key: x[key] + dx[key]*dt for key in dx.keys()})
 
@@ -729,12 +728,9 @@ class PrognosticsModel(ABC):
         if not isinstance(time, Number) or time < 0:
             raise ProgModelInputException("'time' must be positive, was {} (type: {})".format(time, type(time)))
 
-        # Configure
-        config = { # Defaults
-            'thresholds_met_eqn': (lambda x: False), # Override threshold
-            'horizon': time
-        }
-        kwargs.update(config) # Config should override kwargs
+        # Override threshold_met_eqn and horizon
+        kwargs['thresholds_met_eqn'] = lambda x: False
+        kwargs['horizon'] = time
 
         return self.simulate_to_threshold(future_loading_eqn, first_output, **kwargs)
  
@@ -832,12 +828,12 @@ class PrognosticsModel(ABC):
             raise ProgModelInputException("threshold_keys must be event names")
 
         # Configure
-        config = { # Defaults
+        config = {  # Defaults
             't0': 0.0,
             'dt': ('auto', 1.0),
             'save_pts': [],
             'save_freq': 10.0,
-            'horizon': 1e100, # Default horizon (in s), essentially inf
+            'horizon': 1e100,  # Default horizon (in s), essentially inf
             'print': False,
             'x': None,
             'progress': False

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -1310,10 +1310,10 @@ class PrognosticsModel(ABC):
         -------
         See examples/generate_surrogate
         """
-        from .data_models import SURROAGATE_METHOD_LOOKUP
+        from prog_models.data_models import SURROGATE_METHOD_LOOKUP
 
-        if method not in SURROAGATE_METHOD_LOOKUP.keys():
-            raise ProgModelInputException("Method {} not supported. Supported methods: {}".format(method, SURROAGATE_METHOD_LOOKUP.keys()))
+        if method not in SURROGATE_METHOD_LOOKUP.keys():
+            raise ProgModelInputException("Method {} not supported. Supported methods: {}".format(method, SURROGATE_METHOD_LOOKUP.keys()))
 
         # Configure
         config = { # Defaults
@@ -1373,7 +1373,7 @@ class PrognosticsModel(ABC):
         if not all([x in self.events for x in config['event_keys']]):
             raise ProgModelInputException(f"Invalid 'event_keys' input value ({config['event_keys']}), must be a subset of the model's events ({self.events}).")
 
-        return SURROAGATE_METHOD_LOOKUP[method](self, load_functions, **config)
+        return SURROGATE_METHOD_LOOKUP[method](self, load_functions, **config)
     
     def to_json(self):
         """

--- a/src/prog_models/utils/calc_error.py
+++ b/src/prog_models/utils/calc_error.py
@@ -29,7 +29,7 @@ def MAX_E(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwar
             Configurable cutoff value, between 0 and 1, that determines the fraction of the data points for which the model must be stable.
             In some cases, a prognostics model will become unstable under certain conditions, after which point the model can no longer represent behavior. 
             stability_tol represents the fraction of the provided argument `times` that are required to be met in simulation, 
-            before the model goes unstable in order to produce a valid estimate of mean squared error. 
+            before the model goes unstable in order to produce a valid estimate of mean squared error.
 
             If the model goes unstable before stability_tol is met, NaN is returned. 
             Else, model goes unstable after stability_tol is met, the mean squared error calculated from data up to the instability is returned.
@@ -85,8 +85,8 @@ def MAX_E(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwar
             if any(np.isnan(z_obs.matrix)):
                 if counter < cutoffThreshold:
                     raise ValueError(f"Model unstable- NAN reached in simulation (t={t}) before cutoff threshold. "
-                                     f"Cutoff threshold is {cutoffThreshold}, or roughly {stability_tol * 100}% of the data")                 
-                else: 
+                                     f"Cutoff threshold is {cutoffThreshold}, or roughly {stability_tol * 100}% of the data")
+                else:
                     warn(f"Model unstable- NaN reached in simulation (t={t})")
                     break
             err_max = max(err_max, np.max(
@@ -117,7 +117,7 @@ def RMSE(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwarg
             Configurable cutoff value, between 0 and 1, that determines the fraction of the data points for which the model must be stable.
             In some cases, a prognostics model will become unstable under certain conditions, after which point the model can no longer represent behavior. 
             stability_tol represents the fraction of the provided argument `times` that are required to be met in simulation, 
-            before the model goes unstable in order to produce a valid estimate of mean squared error. 
+            before the model goes unstable in order to produce a valid estimate of mean squared error.
 
             If the model goes unstable before stability_tol is met, NaN is returned. 
             Else, model goes unstable after stability_tol is met, the mean squared error calculated from data up to the instability is returned.
@@ -144,7 +144,7 @@ def MSE(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwargs
             Configurable cutoff value, between 0 and 1, that determines the fraction of the data points for which the model must be stable.
             In some cases, a prognostics model will become unstable under certain conditions, after which point the model can no longer represent behavior. 
             stability_tol represents the fraction of the provided argument `times` that are required to be met in simulation, 
-            before the model goes unstable in order to produce a valid estimate of mean squared error. 
+            before the model goes unstable in order to produce a valid estimate of mean squared error.
 
             If the model goes unstable before stability_tol is met, NaN is returned. 
             Else, model goes unstable after stability_tol is met, the mean squared error calculated from data up to the instability is returned.
@@ -197,7 +197,7 @@ def MSE(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwargs
             # For example, in LSTM models, the first few inputs will not 
             # produce an output until the model has received enough data
             # This is true for any window-based model
-            if any (np.isnan(z_obs.matrix)):
+            if any(np.isnan(z_obs.matrix)):
                 if counter < cutoffThreshold:
                     raise ValueError(f"Model unstable- NAN reached in simulation (t={t}) before cutoff threshold. "
                                      f"Cutoff threshold is {cutoffThreshold}, or roughly {stability_tol * 100}% of the data")     
@@ -226,7 +226,7 @@ def MAE(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwargs
             Configurable cutoff value, between 0 and 1, that determines the fraction of the data points for which the model must be stable.
             In some cases, a prognostics model will become unstable under certain conditions, after which point the model can no longer represent behavior. 
             stability_tol represents the fraction of the provided argument `times` that are required to be met in simulation, 
-            before the model goes unstable in order to produce a valid estimate of mean squared error. 
+            before the model goes unstable in order to produce a valid estimate of mean squared error.
 
             If the model goes unstable before stability_tol is met, NaN is returned. 
             Else, model goes unstable after stability_tol is met, the mean squared error calculated from data up to the instability is returned.
@@ -308,7 +308,7 @@ def MAPE(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwarg
             Configurable cutoff value, between 0 and 1, that determines the fraction of the data points for which the model must be stable.
             In some cases, a prognostics model will become unstable under certain conditions, after which point the model can no longer represent behavior. 
             stability_tol represents the fraction of the provided argument `times` that are required to be met in simulation, 
-            before the model goes unstable in order to produce a valid estimate of mean squared error. 
+            before the model goes unstable in order to produce a valid estimate of mean squared error.
 
             If the model goes unstable before stability_tol is met, NaN is returned. 
             Else, model goes unstable after stability_tol is met, the mean squared error calculated from data up to the instability is returned.

--- a/src/prog_models/utils/calc_error.py
+++ b/src/prog_models/utils/calc_error.py
@@ -62,7 +62,7 @@ def MAX_E(m, times: List[float], inputs: List[dict], outputs: List[dict], **kwar
              f"Received {stability_tol}. Resetting value to 0.95")
         stability_tol = 0.95
 
-    counter = 0 
+    counter = 0
     t_last = times[0]
     err_max = 0
     z_obs = m.output(x)  # Initialize

--- a/src/prog_models/utils/containers.py
+++ b/src/prog_models/utils/containers.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from prog_models.exceptions import ProgModelTypeError
 
+
 class DictLikeMatrixWrapper():
     """
     A container that behaves like a dictionary, but is backed by a numpy array, which is itself directly accessible. This is used for model states, inputs, and outputs- and enables efficient matrix operations.
@@ -58,7 +59,6 @@ class DictLikeMatrixWrapper():
         index = self._keys.index(key)   #the int value index for the key given
         self.matrix[index] = np.atleast_1d(value)
 
-    
     def __delitem__(self, key: str) -> None:
         """
         removes row associated with key

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -28,18 +28,19 @@ class PrognosticsModelParameters(UserDict):
     Args:
         model: PrognosticsModel for which the params correspond
         dict_in: Initial parameters
-        callbacks: Any callbacks for derived parameters f(parameters) : updates (dict)
+        callbacks: Any callbacks for derived parameters f(parameters): updates (dict)
     """
     def __init__(self, model: "PrognosticsModel", dict_in: dict = {}, callbacks: dict = {}, _copy: bool = True):
         super().__init__()
         self._m = model
         self.callbacks = {}
-        # Note: Callbacks are set to empty to prevent calling callbacks with a partial or empty dict on line 32. 
+        # Note: Callbacks are set to empty to prevent calling callbacks with a
+        # partial or empty dict on line 32.
         for (key, value) in dict_in.items():
             self.__setitem__(key, value, _copy=_copy)
 
         # Add and run callbacks
-        # Has to be done here so the base parameters are all set 
+        # Has to be done here so the base parameters are all set
         self.callbacks = callbacks
         for key in callbacks:
             if key in self:
@@ -54,13 +55,13 @@ class PrognosticsModelParameters(UserDict):
         if set(self.data.keys()) != set(other.data.keys()):
             return False
         for key, value in self.data.items():
-            if not np.all(value == other[key]): 
-                  # Note: np.all is used to handle numpy array elements
-                  # Otherwise value == other[key] would return a numpy array of bools for each element
-                  return False
+            if not np.all(value == other[key]):
+                # Note: np.all is used to handle numpy array elements
+                # Otherwise value == other[key] would return a numpy array of
+                # bools for each element
+                return False
         return True
-        
-
+    
     def copy(self):
         return self.__class__(self._m, self.data, self.callbacks, _copy=False)
 
@@ -93,7 +94,8 @@ class PrognosticsModelParameters(UserDict):
                 changes = callback(self)
                 self.update(changes)  # Merge in changes
 
-        # Handle setting integration_method. This will override the next_state method
+        # Handle setting integration_method.
+        # This will override the next_state method
         if key == 'integration_method':
             if self._m.is_discrete and self._m.is_state_transition_model:
                 raise ProgModelTypeError(
@@ -137,7 +139,8 @@ class PrognosticsModelParameters(UserDict):
                     fcn = process_noise_functions['gaussian']
                     self._m.apply_process_noise = types.MethodType(fcn, self._m)
                 
-                # Make sure every key is present (single value already handled above)
+                # Make sure every key is present
+                # (single value already handled above)
                 if not all([key in self['process_noise'] for key in self._m.states]):
                     raise ProgModelTypeError("Process noise must have every key in model.states")
 
@@ -172,7 +175,8 @@ class PrognosticsModelParameters(UserDict):
                     fcn = measurement_noise_functions['gaussian']
                     self._m.apply_measurement_noise = types.MethodType(fcn, self._m)
                     
-                # Make sure every key is present (single value already handled above)
+                # Make sure every key is present
+                # (single value already handled above)
                 if not all([key in self['measurement_noise'] for key in self._m.outputs]):
                     raise ProgModelTypeError("Measurement noise must have ever key in model.outputs")
 

--- a/src/prog_models/utils/parameters.py
+++ b/src/prog_models/utils/parameters.py
@@ -16,7 +16,7 @@ from prog_models.utils.size import getsizeof
 from prog_models.exceptions import ProgModelTypeError
 
 from typing import TYPE_CHECKING
-if TYPE_CHECKING: # Fix circular import issue in PrognosticsModelParameters init
+if TYPE_CHECKING:  # Fix circular import issue in PrognosticsModelParameters init
     from prog_models.prognostics_model import PrognosticsModel
 
 
@@ -91,7 +91,7 @@ class PrognosticsModelParameters(UserDict):
         if key in self.callbacks:
             for callback in self.callbacks[key]:
                 changes = callback(self)
-                self.update(changes) # Merge in changes
+                self.update(changes)  # Merge in changes
 
         # Handle setting integration_method. This will override the next_state method
         if key == 'integration_method':

--- a/src/prog_models/utils/progress_bar.py
+++ b/src/prog_models/utils/progress_bar.py
@@ -3,7 +3,7 @@
 
 
 class ProgressBar():
-    def __init__(self, n : int, prefix : str='', suffix : str='', decimals : float=1, print_length : int=100, fill : str='█', print_end : str=" "):
+    def __init__(self, n: int, prefix: str = '', suffix: str = '', decimals: float = 1, print_length: int = 100, fill: str = '█', print_end: str = " "):
         self.n = n
         self.prefix = prefix
         self.suffix = suffix
@@ -11,14 +11,13 @@ class ProgressBar():
         self.print_length = print_length
         self.fill = fill
         self.print_end = print_end
-        print('\r%s |%s| %s%% %s\n' % (self.prefix, self.fill * 0 + '-' * (self.print_length - 0), 0.0, self.suffix), end = self.print_end)
+        print('\r%s |%s| %s%% %s\n' % (self.prefix, self.fill * 0 + '-' * (self.print_length - 0), 0.0, self.suffix), end=self.print_end)
 
-    def __call__(self, iteration : int) -> None:
+    def __call__(self, iteration: int) -> None:
         percent = ("{0:." + str(self.decimals) + "f}").format(100 * (iteration / float(self.n)))
         filledLength = int(self.print_length * iteration // self.n)
         bar = self.fill * filledLength + '-' * (self.print_length - filledLength)
-        print('\r%s |%s| %s%% %s\n' % (self.prefix, bar, percent, self.suffix), end = self.print_end)
+        print('\r%s |%s| %s%% %s\n' % (self.prefix, bar, percent, self.suffix), end=self.print_end)
         # Print New Line on Complete
         if iteration == self.n:
             print('')
-            

--- a/src/prog_models/utils/serialization.py
+++ b/src/prog_models/utils/serialization.py
@@ -8,9 +8,10 @@ from prog_models.utils.containers import DictLikeMatrixWrapper
 
 __all__ = ['CustomEncoder', 'custom_decoder']
 
+
 class CustomEncoder(json.JSONEncoder):
     """
-    Custom encoder to serialize parameters 
+    Custom encoder to serialize parameters
     """
     def default(self, o):
         if isinstance(o, np.ndarray):
@@ -19,8 +20,8 @@ class CustomEncoder(json.JSONEncoder):
             dict_temp = {k: v for k, v in o.items()}
             dict_temp['_original_type'] = 'DictLikeMatrixWrapper'
             return dict_temp
-        elif isinstance(o,np.bool_):
-            return bool(o) 
+        elif isinstance(o, np.bool_):
+            return bool(o)
         else: 
             import pickle
             from base64 import b64encode
@@ -30,22 +31,23 @@ class CustomEncoder(json.JSONEncoder):
             save_temp['_original_type'] = 'pickled'
             return save_temp
 
+
 def custom_decoder(o):
     """
-    Custom decoder to deserialize parameters 
+    Custom decoder to deserialize parameters
     """
-    if isinstance(o,dict) and '_original_type' in o.keys():
+    if isinstance(o, dict) and '_original_type' in o.keys():
         if o['_original_type'] == 'ndarray':
             return np.array(o['_data'])
         elif o['_original_type'] == 'DictLikeMatrixWrapper':
             del o['_original_type']
-            return DictLikeMatrixWrapper(list(o.keys()),o)
+            return DictLikeMatrixWrapper(list(o.keys()), o)
         elif o['_original_type'] == 'pickled':
             import pickle
             from base64 import b64decode
             pkl_temp1 = o['_data'].encode()
             pkl_temp2 = b64decode(pkl_temp1)
             return pickle.loads(pkl_temp2)
-        else: 
+        else:
             raise Exception(f"Type {o['_original_type']} not supported by PrognosticsModel json decoder")
     return o

--- a/src/prog_models/utils/size.py
+++ b/src/prog_models/utils/size.py
@@ -18,8 +18,8 @@ def object_handler(o):
     return chain.from_iterable(o.__dict__.items())
 
 
-# Set of handlers that describe how to estimate the size of the payload of an object of a given type
-# in format {type: handler}
+# Set of handlers that describe how to estimate the size of the payload of an
+# object of a given type in format {type: handler}
 all_handlers = {tuple: iter,
                 list: iter,
                 np.ndarray: lambda a: iter(list(a.flat)),

--- a/src/prog_models/visualize.py
+++ b/src/prog_models/visualize.py
@@ -21,7 +21,7 @@ mpl.rcParams['savefig.dpi']      = 300
 
 # VISUALIZE FUNCTIONS
 # ==========================
-def get_subplot_dim(num_subplots : int, rowfirst : bool = True) -> tuple:
+def get_subplot_dim(num_subplots: int, rowfirst: bool = True) -> tuple:
     """
     Compute the number of rows and columns (nrows, ncols) for a figure with multiple subplots.
     The function returns number of rows and columns given num_subplots.
@@ -71,7 +71,7 @@ def get_subplot_dim(num_subplots : int, rowfirst : bool = True) -> tuple:
                 nrows += 1
     return nrows, ncols
 
-def set_plot_options(opt : dict) -> dict:
+def set_plot_options(opt: dict) -> dict:
     """
     Set default plot options by integrating the options specified by the user in 'opt'
     The visualize library works with specific values to generate the plots.
@@ -168,7 +168,7 @@ def set_plot_options(opt : dict) -> dict:
 
     return opt
 
-def set_legend_options(leg_opt : dict, s_names : List[str]) -> dict:
+def set_legend_options(leg_opt: dict, s_names: List[str]) -> dict:
     """
     Set all remaining legend options given the legend options already specified by the users "leg_opt", 
     and the names of the time series in the plot "s_names."
@@ -231,7 +231,7 @@ def set_legend_options(leg_opt : dict, s_names : List[str]) -> dict:
 
     return leg_opt
 
-def set_savefig_options(sfo : dict) -> dict:
+def set_savefig_options(sfo: dict) -> dict:
     """
     Set all remaining save figure options given the options already specified by the user "sfo".
 
@@ -269,7 +269,7 @@ def set_savefig_options(sfo : dict) -> dict:
         sfo_list['filename'] = 'timeseries_plot.pdf'
     return sfo
 
-def set_legend(ax : plt.axis, item : int, s_names : List[str], leg_opt : dict) -> plt.axis:
+def set_legend(ax: plt.axis, item: int, s_names: List[str], leg_opt: dict) -> plt.axis:
     """
     Set legend for axis 'ax' for the 'item-th' time series entry. All time series labels are defined in 's_names'.
     For a comprehensive explanation of all legend options, see the Matplotlib guide on their website.
@@ -325,7 +325,7 @@ def set_legend(ax : plt.axis, item : int, s_names : List[str], leg_opt : dict) -
                      framealpha=leg_opt['framealpha'], facecolor=leg_opt['facecolor'],
                      edgecolor=leg_opt['edgecolor'], title=leg_opt['title'])
 
-def display_labels(nrows : int, ncols : int, subplot_num : int, ax : plt.axis, opt : dict, series_names : List[str]) -> None:
+def display_labels(nrows: int, ncols: int, subplot_num: int, ax: plt.axis, opt: dict, series_names: List[str]) -> None:
     """
     Display label option for time series plot
 
@@ -367,7 +367,7 @@ def display_labels(nrows : int, ncols : int, subplot_num : int, ax : plt.axis, o
     elif 'all' in opt['display_labels']:    
         set_labels(ax, opt, series_names)
 
-def extract_option(opt : dict, idx : int, series_names : List[str]) -> str:
+def extract_option(opt: dict, idx: int, series_names: List[str]) -> str:
     """
     Extract option from either dictionary or list of plot options.
     The function takes the option "opt" and returns the option at index "idx" if opt is a list,
@@ -417,7 +417,7 @@ def extract_option(opt : dict, idx : int, series_names : List[str]) -> str:
         return opt[idx]
     return opt
 
-def set_ax_options(ax : plt.axis, opts : dict) -> None:
+def set_ax_options(ax: plt.axis, opts: dict) -> None:
     """
     Set label options for plot axis.
 
@@ -453,7 +453,7 @@ def set_ax_options(ax : plt.axis, opts : dict) -> None:
     if opts['yticks']:
         ax.set_yticklabels(opts['yticks'], rotation=opts['ytick_rotation'], fontsize=opts['ytick_fontsize'])
 
-def set_labels(ax : plt.axis, opt : dict, series_names : List[str], axis : str = 'all') -> None:
+def set_labels(ax: plt.axis, opt: dict, series_names: List[str], axis: str = 'all') -> None:
     """
     Set labels of axis "ax" according to figure options "opt" and the time series names "series_names."
     The function can set both x and y axis when input axis=='all' (default), or rather set only x or y axis (axis='x' or axis='y', respectively).
@@ -498,7 +498,7 @@ def set_labels(ax : plt.axis, opt : dict, series_names : List[str], axis : str =
             ytick_fs  = extract_option(opt['ytick_fontsize'], idx, series_names)
             ax.set_yticklabels(ytick, rotation=ytick_rot, fontsize=ytick_fs)
 
-def plot_timeseries(t : List[float], s : List[dict], legend : dict = None, options : dict = None) -> plt.figure:
+def plot_timeseries(t: List[float], s: List[dict], legend: dict = None, options: dict = None) -> plt.figure:
     """
     Plot time series 's' parametrized by time 't'.
     The function plot time series (in a single plot or subplots) contained in the array of dictionary s, produced by a prognostic model.
@@ -541,8 +541,8 @@ def plot_timeseries(t : List[float], s : List[dict], legend : dict = None, optio
     
     # Set up options
     # ====================
-    fig_options    = set_plot_options(options)                      # Set up figure options
-    legend_options = set_legend_options(legend, series_names)       # Set up legend options
+    fig_options    = set_plot_options(options)                 # Set up figure options
+    legend_options = set_legend_options(legend, series_names)  # Set up legend options
     
     # Generate figure
     # =============
@@ -574,8 +574,8 @@ def plot_timeseries(t : List[float], s : List[dict], legend : dict = None, optio
                       framealpha=legend_options['framealpha'], facecolor=legend_options['facecolor'],
                       edgecolor=legend_options['edgecolor'], title=legend_options['title'])
     
-    else:   # "Not compact" option: one subplot per time series
-        nrows, ncols = get_subplot_dim(m)   # get the number of subplots
+    else:  # "Not compact" option: one subplot per time series
+        nrows, ncols = get_subplot_dim(m)  # get the number of subplots
         
         # Iterate over all subplots to plot the time series
         for item in range(m):

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -26,7 +26,7 @@ class MockModel():
         'x0': {'a': 1, 'b': 5, 'c': -3.2, 't': 0}
     }
 
-    def initialize(self, u = {}, z = {}):
+    def initialize(self, u={}, z={}):
         return self.StateContainer(self.parameters['x0'])
 
     def next_state(self, x, u, dt):
@@ -52,7 +52,8 @@ class MockProgModel(MockModel, PrognosticsModel):
             }
 
     def threshold_met(self, x):
-        return {key : value < 1e-6 for (key, value) in self.event_state(x).items()}
+        return {
+            key: value < 1e-6 for (key, value) in self.event_state(x).items()}
 
 def derived_callback(config):
     return {
@@ -65,8 +66,8 @@ def derived_callback2(config):
     }
 
 def derived_callback3(config):
-    return {  # Testing 2nd chained update 
-        'p4': -2 * config['p2'], 
+    return {  # Testing 2nd chained update
+        'p4': -2 * config['p2'],
     }
 
 class MockModelWithDerived(MockProgModel):

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,18 +1,11 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
-from copy import deepcopy
-import io
-import numpy as np
-from os.path import dirname, join
-import pickle
-import sys
 import unittest
 
 from prog_models import *
 from prog_models.models import *
 from prog_models.models.test_models.linear_models import (
-    OneInputNoOutputNoEventLM, OneInputOneOutputNoEventLM, OneInputNoOutputOneEventLM, OneInputOneOutputNoEventLMPM)
-from prog_models.models.thrown_object import LinearThrownObject
+    OneInputOneOutputNoEventLM, OneInputNoOutputOneEventLM, OneInputOneOutputNoEventLMPM)
 
 class TestCompositeModel(unittest.TestCase):
     def test_composite_broken(self):
@@ -147,7 +140,7 @@ class TestCompositeModel(unittest.TestCase):
         # Propogate again
         x = m_composite.next_state(x, u, 1)
         self.assertSetEqual(set(x.keys()), {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1'})
-        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 3) # 1 + 2
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 3)  # 1 + 2
         self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 2)
 
         # Test with connections - state, no event

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -14,7 +14,7 @@ from prog_models.data_models import LSTMStateTransitionModel, DataModel, DMDMode
 from prog_models.models import ThrownObject
 
 
-class TestDataModel(unittest.TestCase):      
+class TestDataModel(unittest.TestCase):
     def setUp(self):
         # set stdout (so it wont print)
         sys.stdout = StringIO()
@@ -22,12 +22,12 @@ class TestDataModel(unittest.TestCase):
     def tearDown(self):
         sys.stdout = sys.__stdout__
       
-    def _test_simple_case(self, 
-        DataModelType, 
-        m = ThrownObject(), 
-        max_error=2, 
-        TIMESTEP = 0.01, 
-        WITH_STATES = True, 
+    def _test_simple_case(self,
+        DataModelType,
+        m = ThrownObject(),
+        max_error=2,
+        TIMESTEP = 0.01,
+        WITH_STATES = True,
         WITH_DT = True,
         **kwargs):
 
@@ -48,11 +48,11 @@ class TestDataModel(unittest.TestCase):
             times = [data.times, data.times],
             inputs = [data.inputs, data.inputs],
             outputs = [data.outputs, data.outputs],
-            event_states = [data.event_states, data.event_states],  
+            event_states = [data.event_states, data.event_states],
             output_keys = list(m.outputs),
             save_freq = TIMESTEP,
             validation_split=0.5,
-            **kwargs)  
+            **kwargs)
         
         self.assertIsInstance(m2, DataModelType)
         self.assertIsInstance(m2, DataModel)
@@ -64,9 +64,9 @@ class TestDataModel(unittest.TestCase):
         if isinstance(m2, DMDModel):
             future_loading2 = future_loading
         else:
-            def future_loading2(t, x = None):
-                # Future Loading is a bit complicated here 
-                # Loading for the resulting model includes the data inputs, 
+            def future_loading2(t, x=None):
+                # Future Loading is a bit complicated here
+                # Loading for the resulting model includes the data inputs,
                 # and the output from the last timestep
                 nonlocal t_counter, x_counter
                 z = m.output(x_counter)
@@ -85,7 +85,7 @@ class TestDataModel(unittest.TestCase):
         _stdout = sys.stdout
         sys.stdout = StringIO()
         actual_out = StringIO()
-        m2.summary(file = actual_out)
+        m2.summary(file=actual_out)
         self.assertEqual(sys.stdout.getvalue(), '')
         self.assertNotEqual(actual_out.getvalue(), '')
         sys.stdout = _stdout
@@ -108,7 +108,7 @@ class TestDataModel(unittest.TestCase):
         _stdout = sys.stdout
         sys.stdout = StringIO()
         m2 = LSTMStateTransitionModel.from_model(m, [future_loading], early_stop=False, **cfg)
-        end = sys.stdout.getvalue().rsplit("Epoch ",1)[1]
+        end = sys.stdout.getvalue().rsplit("Epoch ", 1)[1]
         value = int(end.split(f"/{cfg['epochs']}", 1)[0])
         self.assertEqual(value, cfg['epochs'])
 
@@ -116,7 +116,7 @@ class TestDataModel(unittest.TestCase):
         sys.stdout = StringIO()
         # Default = True
         m2 = LSTMStateTransitionModel.from_model(m, [future_loading], **cfg)
-        end = sys.stdout.getvalue().rsplit("Epoch ",1)[1]
+        end = sys.stdout.getvalue().rsplit("Epoch ", 1)[1]
         value = int(end.split(f"/{cfg['epochs']}", 1)[0])
         self.assertNotEqual(value, cfg['epochs'])
         sys.stdout = _stdout
@@ -130,11 +130,11 @@ class TestDataModel(unittest.TestCase):
         self.assertSetEqual(set(m.states), set(keys))
 
         # Create from model
-        LSTMStateTransitionModel(m.parameters['output_model'], m.parameters['state_model'], output_keys = ['x'])
+        LSTMStateTransitionModel(m.parameters['output_model'], m.parameters['state_model'], output_keys=['x'])
         try:
-        # Test pickling model m
+            # Test pickling model m
             with self.assertWarns(RuntimeWarning):
-            # Will raise warning suggesting using save and load from keras.
+                # Will raise warning suggesting using save and load from keras.
                 pickled_m = pickle.dumps(m)
                 m2 = pickle.loads(pickled_m)
                 self.assertIsInstance(m2, LSTMStateTransitionModel)
@@ -175,7 +175,8 @@ class TestDataModel(unittest.TestCase):
         m = ThrownObject()
 
         def future_loading(t, x=None):
-            return m.InputContainer({})  # No input for thrown object 
+            return m.InputContainer({})  # No input for thrown object
+        
         m3 = LSTMStateTransitionModel.from_model(
             m,
             [future_loading for _ in range(5)],
@@ -192,7 +193,7 @@ class TestDataModel(unittest.TestCase):
         x_counter = m.initialize()
 
         def future_loading2(t, x=None):
-            # Future Loading is a bit complicated here 
+            # Future Loading is a bit complicated here
             # Loading for the resulting model includes the data inputs, 
             # and the output from the last timestep
             nonlocal t_counter, x_counter
@@ -219,18 +220,18 @@ class TestDataModel(unittest.TestCase):
             m,
             [future_loading for _ in range(5)],
             dt = [TIMESTEP, TIMESTEP/2, TIMESTEP/4, TIMESTEP*2, TIMESTEP*4],
-            window=2, 
+            window=2,
             epochs=30,
-            add_dt = False)  
+            add_dt = False)
 
         # Should get keys from original model
         self.assertSetEqual(set(m3.inputs), set(['x_t-1']))
         self.assertSetEqual(set(m3.outputs), set(m.outputs))
 
-         # Step 3: Use model to simulate_to time of threshold
+        # Step 3: Use model to simulate_to time of threshold
         t_counter = 0
         x_counter = m.initialize()
-        def future_loading2(t, x = None):
+        def future_loading2(t, x=None):
             # Future Loading is a bit complicated here 
             # Loading for the resulting model includes the data inputs, 
             # and the output from the last timestep

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -10,6 +10,7 @@ import unittest
 from prog_models import PrognosticsModel
 from prog_models.models import ThrownObject
 
+
 class TestDirect(unittest.TestCase):
     def setUp(self):
         # set stdout (so it wont print)

--- a/tests/test_pneumatic_valve.py
+++ b/tests/test_pneumatic_valve.py
@@ -58,7 +58,7 @@ class TestPneumaticValve(unittest.TestCase):
             'wt': array([0]*4)
         }
 
-        x = m.next_state(x0, future_loading(0), 0.1)
+        m.next_state(x0, future_loading(0), 0.1)
 
     def test_pneumatic_valve_with_wear(self):
         # Test using PneumaticValveWithWear

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -2,6 +2,7 @@
 
 import chaospy as cp
 from io import StringIO
+import matplotlib.pyplot as plt
 import sys
 import unittest
 import warnings
@@ -33,40 +34,40 @@ class TestSurrogate(unittest.TestCase):
         with self.assertRaises(ProgModelInputException):
             m.generate_surrogate([load_eqn], save_pts = [10])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], trim_data_to = -1)
+            m.generate_surrogate([load_eqn], trim_data_to=-1)
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], trim_data_to = 'invalid')
+            m.generate_surrogate([load_eqn], trim_data_to='invalid')
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], trim_data_to = 1.5)
+            m.generate_surrogate([load_eqn], trim_data_to=1.5)
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], states = ['invalid'])
+            m.generate_surrogate([load_eqn], states=['invalid'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], states = ['x', 'invalid', 'v'])
+            m.generate_surrogate([load_eqn], states=['x', 'invalid', 'v'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], inputs = ['invalid'])
+            m.generate_surrogate([load_eqn], inputs=['invalid'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], outputs = ['invalid'])
+            m.generate_surrogate([load_eqn], outputs=['invalid'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], outputs = ['invalid', 'x'])    
+            m.generate_surrogate([load_eqn], outputs=['invalid', 'x'])    
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], events = ['invalid'])
+            m.generate_surrogate([load_eqn], events=['invalid'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], events = ['falling', 'impact', 'invalid'])
+            m.generate_surrogate([load_eqn], events=['falling', 'impact', 'invalid'])
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], stability_tol = -1)
+            m.generate_surrogate([load_eqn], stability_tol=-1)
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], stability_tol = 'invalid')
+            m.generate_surrogate([load_eqn], stability_tol='invalid')
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], training_noise = -1)
+            m.generate_surrogate([load_eqn], training_noise=-1)
         with self.assertRaises(ProgModelInputException):
-            m.generate_surrogate([load_eqn], training_noise = ['invalid'])
+            m.generate_surrogate([load_eqn], training_noise=['invalid'])
     
     def test_surrogate_basic_thrown_object(self):
-        m = ThrownObject(process_noise = 0, measurement_noise = 0)
-        def load_eqn(t = None, x = None):
+        m = ThrownObject(process_noise=0, measurement_noise=0)
+        def load_eqn(t=None, x=None):
             return m.InputContainer({})
         
-        surrogate = m.generate_surrogate([load_eqn], dt = 0.1, save_freq = 0.25, threshold_keys = 'impact', training_noise=0)
+        surrogate = m.generate_surrogate([load_eqn], dt=0.1, save_freq=0.25, threshold_keys='impact', training_noise=0)
         self.assertEqual(surrogate.dt, 0.25)
 
         self.assertListEqual(surrogate.states, [stateTest for stateTest in m.states if (stateTest not in m.outputs and stateTest not in m.events)] + m.outputs + m.events)
@@ -85,7 +86,7 @@ class TestSurrogate(unittest.TestCase):
         surrogate_results = surrogate.simulate_to_threshold(load_eqn, **options)
 
         MSE = m.calc_error(surrogate_results.times, surrogate_results.inputs, surrogate_results.outputs)
-        self.assertLess(MSE, 10) # Pretty good approx
+        self.assertLess(MSE, 10)  # Pretty good approx
 
         self.assertAlmostEqual(surrogate_results.times[-1], result.times[-1], delta=0.26)
         for i in range(min(len(result.times), len(surrogate_results.times))):


### PR DESCRIPTION
Some cleanup using results form linter. 

Cleanup is to ensure compliance with Python Style Guide. Small things like:
* functions should be in format def f(arg: type = default, arg: type, arg=default) -> type
* Two spaces between code and comment (e.g., code  # comment)
* Removing unused imports
* Dont use import *
* Limiting line length
* etc.

Shouldn't change function of code, just make it more readable.