### PR TITLE
314 Auto step for piecewise loading profile

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -67,7 +67,7 @@ def run_example():
 
     # Variable (piece-wise) future loading scheme 
     # For a battery, future loading is in term of current 'i' in amps. 
-    Piecewise(
+    future_loading = Piecewise(
         m.InputContainer,
         [600, 900, 1800, 3000, float('inf')],
         {'i': [2, 1, 4, 2, 3]})

--- a/examples/events.py
+++ b/examples/events.py
@@ -13,6 +13,7 @@ Example further illustrating the concept of 'events' which generalizes EOL.
     This example demonstrates how events can be used in your applications. 
 """
 import matplotlib.pyplot as plt
+from prog_models.loading import Piecewise
 from prog_models.models import BatteryElectroChemEOD
 
 def run_example():
@@ -63,20 +64,13 @@ def run_example():
     m = MyBatt()
 
     # 2a: Setup model
-    def future_loading(t, x=None):
-        # Variable (piece-wise) future loading scheme 
-        # For a battery, future loading is in term of current 'i' in amps. 
-        if (t < 600):
-            i = 2
-        elif (t < 900):
-            i = 1
-        elif (t < 1800):
-            i = 4
-        elif (t < 3000):
-            i = 2     
-        else:
-            i = 3
-        return m.InputContainer({'i': i})
+
+    # Variable (piece-wise) future loading scheme 
+    # For a battery, future loading is in term of current 'i' in amps. 
+    Piecewise(
+        m.InputContainer,
+        [600, 900, 1800, 3000, float('inf')],
+        {'i': [2, 1, 4, 2, 3]})
     
     # 2b: Simulate to threshold
     simulated_results = m.simulate_to_threshold(future_loading, threshold_keys=['EOD'], print = True)

--- a/examples/future_loading.py
+++ b/examples/future_loading.py
@@ -7,26 +7,18 @@ Example demonstrating ways to use future loading.
 
 import matplotlib.pyplot as plt
 from numpy.random import normal
+from prog_models.loading import Piecewise, GuassianNoiseLoadWrapper
 from prog_models.models import BatteryCircuit
 from statistics import mean
 
 def run_example(): 
     m = BatteryCircuit()
 
-    ## Example 1: Variable loading 
-    def future_loading(t, x=None):
-        # Variable (piece-wise) future loading scheme 
-        if (t < 600):
-            i = 2
-        elif (t < 900):
-            i = 1
-        elif (t < 1800):
-            i = 4
-        elif (t < 3000):
-            i = 2     
-        else:
-            i = 3
-        return m.InputContainer({'i': i})
+    ## Example 1: Variable (piecewise) loading
+    future_loading = Piecewise(
+        m.InputContainer,
+        [600, 900, 1800, 3000, float('inf')],
+        {'i': [2, 1, 4, 2, 3]})
     
     # Simulate to threshold
     options = {
@@ -68,23 +60,11 @@ def run_example():
 
     ## Example 3: Gaussian Distribution 
     # In this example we will still be doing a variable loading like the first option, but we are going to use a 
-    # gaussian distribution for each input. 
-
-    def future_loading(t, x=None):
-        # Variable (piece-wise) future loading scheme 
-        if (t < 600):
-            i = 2
-        elif (t < 900):
-            i = 1
-        elif (t < 1800):
-            i = 4
-        elif (t < 3000):
-            i = 2     
-        else:
-            i = 3
-        return m.InputContainer({'i': i})
-
-    from prog_models.loading import GuassianNoiseLoadWrapper
+    # gaussian distribution for each input.
+    future_loading = Piecewise(
+        m.InputContainer,
+        [600, 900, 1800, 3000, float('inf')],
+        {'i': [2, 1, 4, 2, 3]})
     future_loading_with_noise = GuassianNoiseLoadWrapper(future_loading, 0.2)
 
     # Simulate to threshold

--- a/examples/sim.py
+++ b/examples/sim.py
@@ -20,13 +20,13 @@ def run_example():
     # Step 2: Define future loading function - here we're using a piecewise scheme
     future_loading = Piecewise(
         batt.InputContainer,
-        [600, 900, 1755, 3599, float('inf')],
+        [600, 900, 1800, 3600, float('inf')],
         {'i': [2, 1, 4, 2, 3]})
 
     # simulate for 200 seconds
     print('\n\n------------------------------------------------')
     print('Simulating for 200 seconds\n\n')
-    simulated_results = batt.simulate_to(200, future_loading, print = True, progress = True, stop_pts=[3.5], dt=('auto', 2))
+    simulated_results = batt.simulate_to(200, future_loading, print = True, progress = True)
     # The result of the simulation is now stored in simulated_results.
     # You can access the results by accessing the individual variables:
     #   times, inputs, states, outputs, event_states

--- a/examples/sim.py
+++ b/examples/sim.py
@@ -8,32 +8,25 @@ Example of a battery being simulated for a set period of time and then till thre
 import matplotlib.pyplot as plt
 from prog_models.models import BatteryElectroChem
 from prog_models.models import BatteryCircuit as Battery
+from prog_models.loading import Piecewise
 
 # VVV Uncomment this to use Electro Chemistry Model VVV
 # Battery = BatteryElectroChem
 
-def run_example(): 
+def run_example():
     # Step 1: Create a model object
     batt = Battery()
 
-    # Step 2: Define future loading function 
-    def future_loading(t, x=None):
-        # Variable (piece-wise) future loading scheme 
-        if (t < 600):
-            i = 2
-        elif (t < 900):
-            i = 1
-        elif (t < 1800):
-            i = 4
-        elif (t < 3000):
-            i = 2
-        else:
-            i = 3
-        return batt.InputContainer({'i': i})
+    # Step 2: Define future loading function - here we're using a piecewise scheme
+    future_loading = Piecewise(
+        batt.InputContainer,
+        [600, 900, 1755, 3599, float('inf')],
+        {'i': [2, 1, 4, 2, 3]})
+
     # simulate for 200 seconds
     print('\n\n------------------------------------------------')
     print('Simulating for 200 seconds\n\n')
-    simulated_results = batt.simulate_to(200, future_loading, print = True, progress = True)
+    simulated_results = batt.simulate_to(200, future_loading, print = True, progress = True, stop_pts=[3.5], dt=('auto', 2))
     # The result of the simulation is now stored in simulated_results.
     # You can access the results by accessing the individual variables:
     #   times, inputs, states, outputs, event_states
@@ -49,15 +42,17 @@ def run_example():
     print('\n\n------------------------------------------------')
     print('Simulating to threshold\n\n')
     options = {
-        'save_freq': 100, # Frequency at which results are saved
-        'dt': 2, # Timestep
+        'save_freq': 100,  # Frequency at which results are saved
+        'dt': 2,  # Timestep
         'print': True,
         'progress': True
     }
     simulated_results = batt.simulate_to_threshold(future_loading, **options)
 
     # Alternately, you can set a max step size and allow step size to be adjusted automatically
-    options['dt'] = ('auto', 2)  # set step size automatically, with a max of 2 seconds
+    options['dt'] = ('auto', 2)
+    # set step size automatically, with a max of 2 seconds. Setting max step size automatically will allow the 
+    # save points, stop points, and future loading change points to be met exactly
     options['save_freq'] = 201  # Save every 201 seconds
     options['save_pts'] = [250, 772, 1023]  # Special points we sould like to see reported
     simulated_results = batt.simulate_to_threshold(future_loading, **options)

--- a/src/prog_models/loading.py
+++ b/src/prog_models/loading.py
@@ -95,3 +95,44 @@ class GuassianNoiseLoadWrapper():
         for key, value in input.items():
             input[key] = np.random.normal(value, self.std)
         return input
+
+
+class Piecewise():
+    """
+    This is a simple piecewise future loading class. It takes a list of times and values and returns the value that corresponds to the current time. The object replaces the future_loading_eqn for simulate_to and simulate_to_threshold.
+
+    Args
+    -----
+        InputContainer : class
+            The InputContainer class for the model (model.InputContainer)
+        times : list
+            A list of times (s)
+        values : list
+            A list of values
+
+    Example
+    -------
+    >>> from prog_models.loading import Piecewise
+    >>> m = SomeModel()
+    >>> future_load = Piecewise(m.InputContainer, [0, 10, 20], [0, 1, 0])
+    >>> m.simulate_to_threshold(future_load)
+    """
+    def __init__(self, InputContainer, times, values):
+        self.InputContainer = InputContainer
+        self.times = times
+        self.values = values
+
+    def __call__(self, t, x=None):
+        """
+        Return the value that corresponds to the current time
+
+        Args:
+            t (float): Time (s)
+            x (StateContaienr, optional): Current state. Defaults to None.
+
+        Returns:
+            InputContainer: The value that corresponds to the current time
+        """
+        return self.InputContainer({
+            key: next(self.values[key][i] for i in range(len(self.times)) if self.times[i] > t)
+            for key in self.values})

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -12,6 +12,7 @@ from typing import Callable, Iterable, List, Sequence
 from warnings import warn
 
 from prog_models.exceptions import ProgModelInputException, ProgModelTypeError, ProgModelException, ProgModelStateLimitWarning
+from prog_models.loading import Piecewise
 from prog_models.sim_result import SimResult, LazySimResult
 from prog_models.utils import ProgressBar
 from prog_models.utils import calc_error
@@ -760,6 +761,8 @@ class PrognosticsModel(ABC):
             Frequency at which output is saved (s), e.g., save_freq = 10 \n
         save_pts : list[float], optional
             Additional ordered list of custom times where output is saved (s), e.g., save_pts= [50, 75] \n
+        stop_pts : list[float], optional
+            Additional ordered list of custom times where simulation is stopped when dt is auto (s), e.g., stop_pts= [50, 75] \n
         horizon : float, optional
             maximum time that the model will be simulated forward (s), e.g., horizon = 1000 \n
         first_output : OutputContainer, optional
@@ -833,6 +836,7 @@ class PrognosticsModel(ABC):
         config = {  # Defaults
             't0': 0.0,
             'dt': ('auto', 1.0),
+            'stop_pts': [],
             'save_pts': [],
             'save_freq': 10.0,
             'horizon': 1e100,  # Default horizon (in s), essentially inf
@@ -928,6 +932,8 @@ class PrognosticsModel(ABC):
         next_save = next(iterator)
         save_pt_index = 0
         save_pts = config['save_pts']
+        stop_pt_index = 0
+        stop_pts = config['stop_pts'].copy()  # Copy because we may change it
 
         # configure optional intermediate printing
         if config['print']:
@@ -971,9 +977,13 @@ class PrognosticsModel(ABC):
             def next_time(t, x):
                 return dt
         elif dt_mode == 'auto':
-            def next_time(t, x):
+            if isinstance(future_loading_eqn, Piecewise):
+                stop_pts.extend(future_loading_eqn.times)
+                stop_pts = sorted(stop_pts)
+            def next_time(t, x=None):
                 next_save_pt = save_pts[save_pt_index] if save_pt_index < len(save_pts) else float('inf')
-                return min(dt, next_save-t, next_save_pt-t)
+                next_stop_pt = stop_pts[stop_pt_index] if stop_pt_index < len(stop_pts) else float('inf')
+                return min(dt, next_save-t, next_save_pt-t, next_stop_pt-t)
         elif dt_mode != 'function':
             raise ProgModelInputException(f"'dt' mode {dt_mode} not supported. Must be 'constant', 'auto', or a function")
         
@@ -1013,14 +1023,14 @@ class PrognosticsModel(ABC):
             self.parameters['integration_method'] = config['integration_method']
        
         while t < horizon:
-            dt = next_time(t, x)
-            t = t + dt/2
+            dt_i = next_time(t, x)
+            t = t + dt_i/2
             # Use state at midpoint of step to best represent the load during the duration of the step
             # This is sometimes referred to as 'leapfrog integration'
             u = load_eqn(t, x)
-            t = t + dt/2
-            x = next_state(x, u, dt)
-            x = apply_noise(x, dt)
+            t = t + dt_i/2
+            x = next_state(x, u, dt_i)
+            x = apply_noise(x, dt_i)
             x = apply_limits(x)
 
             # Save if at appropriate time
@@ -1035,6 +1045,10 @@ class PrognosticsModel(ABC):
                 # Otherwise save_pt_index would be out of range
                 save_pt_index += 1
                 update_all()
+            elif (stop_pt_index < len(stop_pts)) and (t >= stop_pts[stop_pt_index]):
+                # (stop_pt_index < len(stop_pts)) covers when t is past the last stoppoint
+                # Otherwise save_pt_index would be out of range
+                stop_pt_index += 1
 
             # Update progress bar
             if config['progress']:

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -762,7 +762,7 @@ class PrognosticsModel(ABC):
         save_pts : list[float], optional
             Additional ordered list of custom times where output is saved (s), e.g., save_pts= [50, 75] \n
         stop_pts : list[float], optional
-            Additional ordered list of custom times where simulation is stopped when dt is auto (s), e.g., stop_pts= [50, 75] \n
+            Additional ordered list of custom times where simulation is paused and evaluated (though results are not saved, as with save_pts) when dt is auto (s), e.g., stop_pts= [50, 75] \n
         horizon : float, optional
             maximum time that the model will be simulated forward (s), e.g., horizon = 1000 \n
         first_output : OutputContainer, optional
@@ -1047,7 +1047,7 @@ class PrognosticsModel(ABC):
                 update_all()
             elif (stop_pt_index < len(stop_pts)) and (t >= stop_pts[stop_pt_index]):
                 # (stop_pt_index < len(stop_pts)) covers when t is past the last stoppoint
-                # Otherwise save_pt_index would be out of range
+                # Otherwise stop_pt_index would be out of range
                 stop_pt_index += 1
 
             # Update progress bar

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -5,20 +5,13 @@ import sys
 import unittest
 
 from prog_models.models import BatteryCircuit, BatteryElectroChem, BatteryElectroChemEOL, BatteryElectroChemEOD, BatteryElectroChemEODEOL
+from prog_models.loading import Piecewise
 
-def future_loading(t, x=None):
-    # Variable (piece-wise) future loading scheme 
-    if (t < 600):
-        i = 2
-    elif (t < 900):
-        i = 1
-    elif (t < 1800):
-        i = 4
-    elif (t < 3000):
-        i = 2
-    else:
-        i = 3
-    return {'i': i}
+# Variable (piece-wise) future loading scheme 
+future_loading = Piecewise(
+    dict,
+    [600, 900, 1800, 3000, float('inf')],
+    {'i': [2, 1, 4, 2, 3]})
 
 
 class TestBattery(unittest.TestCase):


### PR DESCRIPTION
Two related changes:
1. Added a new loading scheme that defines the logic for piecewise loading profiles
2. Added "stop points". These are points where the simulation will be sure to stop if using "auto" dt. This is important if there are point in the loading profile that you want to capture
3. Will automatically grab the inflection points of the piecewise scheme as stop points (if using "auto" dt)