### PR TITLE
Adding explicit import of mock.patch as bugfix

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,7 @@ from os.path import dirname, join
 import pkgutil
 import sys
 import unittest
+from unittest.mock import patch
 
 sys.path.append(join(dirname(__file__), ".."))  # needed to access examples
 from examples import *
@@ -17,7 +18,7 @@ def make_test_function(example):
     def test(self):
         ex = import_module("examples." + example)
 
-        with unittest.mock.patch('matplotlib.pyplot.show'):
+        with patch('matplotlib.pyplot.show'):
             ex.run_example()
     return test
 


### PR DESCRIPTION
This PR addresses a bug in using the 'mock' attribute of unittest by explicitly importing mock in each test that uses this