### PR TITLE
warn_once

### DIFF
--- a/src/prog_models/data_models/dmd.py
+++ b/src/prog_models/data_models/dmd.py
@@ -7,6 +7,7 @@ from scipy.interpolate import interp1d
 import types
 from warnings import warn
 
+from prog_models.exceptions import warn_once
 from prog_models.sim_result import SimResult, LazySimResult
 from prog_models import LinearModel, PrognosticsModel
 from prog_models.data_models import DataModel
@@ -63,7 +64,7 @@ class DMDModel(LinearModel, DataModel):
     def __new__(cls, dmd_matrix, *args, **kwargs):
         if isinstance(dmd_matrix, PrognosticsModel):
             # Keep for backwards compatability (in first version, model was passed into constructor)
-            warn('Passing a PrognosticsModel into DMDModel is deprecated and will be removed in v1.5.  Please use DMDModel.from_model instead', DeprecationWarning)
+            warn_once('Passing a PrognosticsModel into DMDModel is deprecated and will be removed in v1.6.  Please use DMDModel.from_model instead', DeprecationWarning)
             return cls.from_model(dmd_matrix, args[0], **kwargs)
         return DataModel.__new__(cls)
 
@@ -433,7 +434,7 @@ class DMDModel(LinearModel, DataModel):
         
         # Interpolate results to be at user-desired time step
         if 'dt' in kwargs:
-            warn("dt is not used in DMD approximation")
+            warn_once("dt is not used in DMD approximation")
 
         # Default parameters
         config = {

--- a/src/prog_models/data_models/lstm_model.py
+++ b/src/prog_models/data_models/lstm_model.py
@@ -8,6 +8,7 @@ import numpy as np
 import sys
 from warnings import warn
 
+from prog_models.exceptions import warn_once
 from prog_models.data_models import DataModel
 from prog_models.sim_result import SimResult
 
@@ -94,7 +95,7 @@ class LSTMStateTransitionModel(DataModel):
         self.parameters.__setitem__('history', self.history, _copy = False)        
 
     def __getstate__(self):
-        warn("LSTMStateTransitionModel uses a Keras model, which does not always support pickling. We recommend that you use the keras save and load model functions instead with m.model", RuntimeWarning)
+        warn_once("LSTMStateTransitionModel uses a Keras model, which does not always support pickling. We recommend that you use the keras save and load model functions instead with m.model", RuntimeWarning)
         return ((), self.parameters.data)
 
     def __eq__(self, other):

--- a/src/prog_models/exceptions.py
+++ b/src/prog_models/exceptions.py
@@ -1,8 +1,20 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
+from warnings import warn
+
 
 class ProgModelStateLimitWarning(Warning):
     """
     Prognostics State Limit Warning - indicates the model state was outside the limits, and was adjusted
     """
+
+
+warnings_seen = set()
+
+
+def warn_once(msg, *args, **kwargs):
+    if msg not in warnings_seen:
+        # First time warning
+        warnings_seen.add(msg)
+        warn(msg, *args, **kwargs)

--- a/src/prog_models/prognostics_model.py
+++ b/src/prog_models/prognostics_model.py
@@ -11,7 +11,7 @@ import numpy as np
 from typing import List  # Still needed until v3.9
 from warnings import warn
 
-from prog_models.exceptions import ProgModelStateLimitWarning
+from prog_models.exceptions import ProgModelStateLimitWarning, warn_once
 from prog_models.loading import Piecewise
 from prog_models.sim_result import SimResult, LazySimResult
 from prog_models.utils import ProgressBar, calc_error, input_validation
@@ -470,9 +470,9 @@ class PrognosticsModel(ABC):
         | z = m.output(x) # Returns m.OutputContainer({'z1': 2.2})
         """
         if self.is_direct_model:
-            warn('This Direct Model does not support output estimation. Did you mean to call time_of_event?')
+            warn_once('This Direct Model does not support output estimation. Did you mean to call time_of_event?')
         else:
-            warn('This model does not support output estimation.')
+            warn_once('This model does not support output estimation.')
         return self.OutputContainer({})
 
     def __output(self, x):
@@ -1418,19 +1418,19 @@ class PrognosticsModel(ABC):
         config.update(kwargs)
 
         if 'inputs' in config:
-            warn("Use 'input_keys' instead of 'inputs'. 'inputs' will be deprecated in v1.5")
+            warn_once("Use 'input_keys' instead of 'inputs'. 'inputs' was deprecated and will be removed in v1.6", DeprecationWarning)
             config['input_keys'] = config['inputs']
             del config['inputs']
         if 'states' in config:
-            warn("Use 'state_keys' instead of 'states'. 'states' will be deprecated in v1.5")
+            warn_once("Use 'state_keys' instead of 'states'. 'states' was deprecated and will be removed in v1.6", DeprecationWarning)
             config['state_keys'] = config['states']
             del config['states']
         if 'outputs' in config:
-            warn("Use 'output_keys' instead of 'outputs'. 'outputs' will be deprecated in v1.5")
+            warn_once("Use 'output_keys' instead of 'outputs'. 'outputs' was deprecated and will be removed in v1.6", DeprecationWarning)
             config['output_keys'] = config['outputs']
             del config['outputs']
         if 'events' in config:
-            warn("Use 'event_keys' instead of 'events'. 'events' will be deprecated in v1.5")
+            warn_once("Use 'event_keys' instead of 'events'. 'events' was deprecated and will be deprecated in v1.6")
             config['event_keys'] = config['events']
             del config['events']
 

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -531,6 +531,10 @@ class TestSurrogate(unittest.TestCase):
         
         surrogate = m.generate_surrogate([load_eqn], dt=0.1, save_freq=0.25, threshold_keys='impact', training_noise=0)
 
+        # Reset warnings seen so warning will occur
+        from prog_models import exceptions
+        exceptions.warnings_seen = set() 
+
         with self.assertWarns(Warning):
             surrogate.simulate_to_threshold(load_eqn, dt=0.05)
 


### PR DESCRIPTION
Add ability to only throw a warning the first time something occurs. This makes sense for things like Deprecated warnings, that warning the user once is enough. But should not be used for things that are a function of input (e.g., unstable model, input out of range).

This is a quality of life improvement